### PR TITLE
Add stitch method tracking, panorama filtering, and user ratings

### DIFF
--- a/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
+++ b/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Api.Services.V2;
@@ -30,6 +31,13 @@ public class PanoramasController : ControllerBase
     /// <param name="sol_min">Minimum sol</param>
     /// <param name="sol_max">Maximum sol</param>
     /// <param name="min_photos">Minimum number of photos in panorama</param>
+    /// <param name="stitch_status">Filter by stitch status: completed, failed, processing, not_started</param>
+    /// <param name="stitch_method">Filter by stitch method: feature_match, telemetry_projection</param>
+    /// <param name="mosaic_type">Filter by mosaic type: single_row, multi_row</param>
+    /// <param name="quality">Filter by quality tier: partial, half, wide, full</param>
+    /// <param name="min_rating">Minimum average rating (1.0-5.0)</param>
+    /// <param name="sort">Sort field: sol (default), rating, coverage, photos</param>
+    /// <param name="order">Sort direction: asc, desc (default)</param>
     /// <param name="page">Page number (1-indexed)</param>
     /// <param name="per_page">Items per page (default: 25, max: 100)</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -41,6 +49,13 @@ public class PanoramasController : ControllerBase
         [FromQuery] int? sol_min = null,
         [FromQuery] int? sol_max = null,
         [FromQuery] int? min_photos = null,
+        [FromQuery] string? stitch_status = null,
+        [FromQuery] string? stitch_method = null,
+        [FromQuery] string? mosaic_type = null,
+        [FromQuery] string? quality = null,
+        [FromQuery] double? min_rating = null,
+        [FromQuery] string? sort = null,
+        [FromQuery] string? order = null,
         [FromQuery] int page = 1,
         [FromQuery] int per_page = 25,
         CancellationToken cancellationToken = default)
@@ -70,11 +85,30 @@ public class PanoramasController : ControllerBase
             });
         }
 
+        if (min_rating.HasValue && (min_rating.Value < 1.0 || min_rating.Value > 5.0))
+        {
+            return BadRequest(new ApiError
+            {
+                Type = "/errors/validation-error",
+                Title = "Validation Error",
+                Status = 400,
+                Detail = "min_rating must be between 1.0 and 5.0",
+                Instance = Request.Path
+            });
+        }
+
         var response = await _panoramaService.GetPanoramasAsync(
             rovers,
             sol_min,
             sol_max,
             min_photos,
+            stitch_status,
+            stitch_method,
+            mosaic_type,
+            quality,
+            min_rating,
+            sort,
+            order,
             page,
             per_page,
             cancellationToken);
@@ -110,4 +144,83 @@ public class PanoramasController : ControllerBase
 
         return Ok(panorama);
     }
+
+    /// <summary>
+    /// Rate a panorama (1-5 stars). Requires API key. Same key can update their rating.
+    /// </summary>
+    /// <param name="id">Panorama ID</param>
+    /// <param name="request">Rating request body</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    [HttpPost("{id}/rating")]
+    [ProducesResponseType(typeof(RatingResponse), 200)]
+    [ProducesResponseType(typeof(ApiError), 400)]
+    [ProducesResponseType(typeof(ApiError), 401)]
+    public async Task<IActionResult> RatePanorama(
+        string id,
+        [FromBody] RatingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var clientId = HttpContext.Items["ApiKeyId"]?.ToString();
+        if (string.IsNullOrEmpty(clientId))
+        {
+            return Unauthorized(new ApiError
+            {
+                Type = "/errors/unauthorized",
+                Title = "Unauthorized",
+                Status = 401,
+                Detail = "API key required to rate panoramas",
+                Instance = Request.Path
+            });
+        }
+
+        if (request.Rating < 1 || request.Rating > 5)
+        {
+            return BadRequest(new ApiError
+            {
+                Type = "/errors/validation-error",
+                Title = "Validation Error",
+                Status = 400,
+                Detail = "Rating must be between 1 and 5",
+                Instance = Request.Path
+            });
+        }
+
+        var result = await _panoramaService.UpsertRatingAsync(id, clientId, request.Rating, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Get rating information for a panorama
+    /// </summary>
+    /// <param name="id">Panorama ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    [HttpGet("{id}/rating")]
+    [ProducesResponseType(typeof(RatingResponse), 200)]
+    public async Task<IActionResult> GetRating(
+        string id,
+        CancellationToken cancellationToken = default)
+    {
+        var clientId = HttpContext.Items["ApiKeyId"]?.ToString();
+        var result = await _panoramaService.GetRatingAsync(id, clientId, cancellationToken);
+        return Ok(result);
+    }
+}
+
+public record RatingRequest
+{
+    [JsonPropertyName("rating")]
+    public int Rating { get; init; }
+}
+
+public record RatingResponse
+{
+    [JsonPropertyName("average_rating")]
+    public double AverageRating { get; init; }
+
+    [JsonPropertyName("rating_count")]
+    public int RatingCount { get; init; }
+
+    [JsonPropertyName("user_rating")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? UserRating { get; init; }
 }

--- a/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
+++ b/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Api.Services.V2;
@@ -15,6 +14,19 @@ public class PanoramasController : ControllerBase
 {
     private readonly IPanoramaService _panoramaService;
     private readonly ILogger<PanoramasController> _logger;
+
+    private static readonly HashSet<string> ValidSorts = new(StringComparer.OrdinalIgnoreCase)
+        { "sol", "rating", "coverage", "photos" };
+    private static readonly HashSet<string> ValidOrders = new(StringComparer.OrdinalIgnoreCase)
+        { "asc", "desc" };
+    private static readonly HashSet<string> ValidStitchStatuses = new(StringComparer.OrdinalIgnoreCase)
+        { "completed", "failed", "processing", "not_started" };
+    private static readonly HashSet<string> ValidStitchMethods = new(StringComparer.OrdinalIgnoreCase)
+        { "feature_match", "telemetry_projection" };
+    private static readonly HashSet<string> ValidMosaicTypes = new(StringComparer.OrdinalIgnoreCase)
+        { "single_row", "multi_row" };
+    private static readonly HashSet<string> ValidQualities = new(StringComparer.OrdinalIgnoreCase)
+        { "partial", "half", "wide", "full" };
 
     public PanoramasController(
         IPanoramaService panoramaService,
@@ -60,42 +72,32 @@ public class PanoramasController : ControllerBase
         [FromQuery] int per_page = 25,
         CancellationToken cancellationToken = default)
     {
-        // Validate pagination
         if (page < 1)
-        {
-            return BadRequest(new ApiError
-            {
-                Type = "/errors/validation-error",
-                Title = "Validation Error",
-                Status = 400,
-                Detail = "Page number must be >= 1",
-                Instance = Request.Path
-            });
-        }
+            return ValidationError("Page number must be >= 1");
 
         if (per_page < 1 || per_page > 100)
-        {
-            return BadRequest(new ApiError
-            {
-                Type = "/errors/validation-error",
-                Title = "Validation Error",
-                Status = 400,
-                Detail = "Per page must be between 1 and 100",
-                Instance = Request.Path
-            });
-        }
+            return ValidationError("Per page must be between 1 and 100");
 
         if (min_rating.HasValue && (min_rating.Value < 1.0 || min_rating.Value > 5.0))
-        {
-            return BadRequest(new ApiError
-            {
-                Type = "/errors/validation-error",
-                Title = "Validation Error",
-                Status = 400,
-                Detail = "min_rating must be between 1.0 and 5.0",
-                Instance = Request.Path
-            });
-        }
+            return ValidationError("min_rating must be between 1.0 and 5.0");
+
+        if (sort != null && !ValidSorts.Contains(sort))
+            return ValidationError($"Invalid sort value '{sort}'. Valid values: sol, rating, coverage, photos");
+
+        if (order != null && !ValidOrders.Contains(order))
+            return ValidationError($"Invalid order value '{order}'. Valid values: asc, desc");
+
+        if (stitch_status != null && !ValidStitchStatuses.Contains(stitch_status))
+            return ValidationError($"Invalid stitch_status value '{stitch_status}'. Valid values: completed, failed, processing, not_started");
+
+        if (stitch_method != null && !ValidStitchMethods.Contains(stitch_method))
+            return ValidationError($"Invalid stitch_method value '{stitch_method}'. Valid values: feature_match, telemetry_projection");
+
+        if (mosaic_type != null && !ValidMosaicTypes.Contains(mosaic_type))
+            return ValidationError($"Invalid mosaic_type value '{mosaic_type}'. Valid values: single_row, multi_row");
+
+        if (quality != null && !ValidQualities.Contains(quality))
+            return ValidationError($"Invalid quality value '{quality}'. Valid values: partial, half, wide, full");
 
         var response = await _panoramaService.GetPanoramasAsync(
             rovers,
@@ -173,17 +175,11 @@ public class PanoramasController : ControllerBase
             });
         }
 
+        if (!IsValidPanoramaIdFormat(id))
+            return ValidationError("Invalid panorama ID format. Expected: pano_{rover}_{sol}_{index}");
+
         if (request.Rating < 1 || request.Rating > 5)
-        {
-            return BadRequest(new ApiError
-            {
-                Type = "/errors/validation-error",
-                Title = "Validation Error",
-                Status = 400,
-                Detail = "Rating must be between 1 and 5",
-                Instance = Request.Path
-            });
-        }
+            return ValidationError("Rating must be between 1 and 5");
 
         var result = await _panoramaService.UpsertRatingAsync(id, clientId, request.Rating, cancellationToken);
         return Ok(result);
@@ -204,23 +200,25 @@ public class PanoramasController : ControllerBase
         var result = await _panoramaService.GetRatingAsync(id, clientId, cancellationToken);
         return Ok(result);
     }
-}
 
-public record RatingRequest
-{
-    [JsonPropertyName("rating")]
-    public int Rating { get; init; }
-}
+    private static bool IsValidPanoramaIdFormat(string id)
+    {
+        var parts = id.Split('_');
+        return parts.Length >= 4 &&
+               parts[0] == "pano" &&
+               int.TryParse(parts[^2], out _) &&
+               int.TryParse(parts[^1], out _);
+    }
 
-public record RatingResponse
-{
-    [JsonPropertyName("average_rating")]
-    public double AverageRating { get; init; }
-
-    [JsonPropertyName("rating_count")]
-    public int RatingCount { get; init; }
-
-    [JsonPropertyName("user_rating")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? UserRating { get; init; }
+    private BadRequestObjectResult ValidationError(string detail)
+    {
+        return BadRequest(new ApiError
+        {
+            Type = "/errors/validation-error",
+            Title = "Validation Error",
+            Status = 400,
+            Detail = detail,
+            Instance = Request.Path
+        });
+    }
 }

--- a/src/MarsVista.Api/DTOs/V2/PanoramaResource.cs
+++ b/src/MarsVista.Api/DTOs/V2/PanoramaResource.cs
@@ -173,8 +173,7 @@ public record PanoramaAttributes
     /// Stitch status, method, and rating information
     /// </summary>
     [JsonPropertyName("stitch")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public StitchInfo? Stitch { get; init; }
+    public StitchInfo Stitch { get; init; } = new();
 }
 
 /// <summary>

--- a/src/MarsVista.Api/DTOs/V2/PanoramaResource.cs
+++ b/src/MarsVista.Api/DTOs/V2/PanoramaResource.cs
@@ -168,6 +168,42 @@ public record PanoramaAttributes
     [JsonPropertyName("vertical_coverage_degrees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public float? VerticalCoverageDegrees { get; init; }
+
+    /// <summary>
+    /// Stitch status, method, and rating information
+    /// </summary>
+    [JsonPropertyName("stitch")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public StitchInfo? Stitch { get; init; }
+}
+
+/// <summary>
+/// Stitch processing information for a panorama
+/// </summary>
+public record StitchInfo
+{
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "not_started";
+
+    [JsonPropertyName("method")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Method { get; init; }
+
+    [JsonPropertyName("width")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Width { get; init; }
+
+    [JsonPropertyName("height")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Height { get; init; }
+
+    [JsonPropertyName("average_rating")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? AverageRating { get; init; }
+
+    [JsonPropertyName("rating_count")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? RatingCount { get; init; }
 }
 
 /// <summary>

--- a/src/MarsVista.Api/DTOs/V2/RatingDtos.cs
+++ b/src/MarsVista.Api/DTOs/V2/RatingDtos.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace MarsVista.Api.DTOs.V2;
+
+public record RatingRequest
+{
+    [JsonPropertyName("rating")]
+    public int Rating { get; init; }
+}
+
+public record RatingResponse
+{
+    [JsonPropertyName("average_rating")]
+    public double AverageRating { get; init; }
+
+    [JsonPropertyName("rating_count")]
+    public int RatingCount { get; init; }
+
+    [JsonPropertyName("user_rating")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? UserRating { get; init; }
+}

--- a/src/MarsVista.Api/Services/V2/IPanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/IPanoramaService.cs
@@ -1,4 +1,3 @@
-using MarsVista.Api.Controllers.V2;
 using MarsVista.Api.DTOs.V2;
 
 namespace MarsVista.Api.Services.V2;

--- a/src/MarsVista.Api/Services/V2/IPanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/IPanoramaService.cs
@@ -1,3 +1,4 @@
+using MarsVista.Api.Controllers.V2;
 using MarsVista.Api.DTOs.V2;
 
 namespace MarsVista.Api.Services.V2;
@@ -15,6 +16,13 @@ public interface IPanoramaService
         int? solMin = null,
         int? solMax = null,
         int? minPhotos = null,
+        string? stitchStatus = null,
+        string? stitchMethod = null,
+        string? mosaicType = null,
+        string? quality = null,
+        double? minRating = null,
+        string? sort = null,
+        string? order = null,
         int pageNumber = 1,
         int pageSize = 25,
         CancellationToken cancellationToken = default);
@@ -24,5 +32,22 @@ public interface IPanoramaService
     /// </summary>
     Task<PanoramaResource?> GetPanoramaByIdAsync(
         string panoramaId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create or update a rating for a panorama
+    /// </summary>
+    Task<RatingResponse> UpsertRatingAsync(
+        string panoramaId,
+        string clientId,
+        int rating,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get rating information for a panorama
+    /// </summary>
+    Task<RatingResponse> GetRatingAsync(
+        string panoramaId,
+        string? clientId = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using MarsVista.Core.Data;
 using MarsVista.Core.Entities;
+using MarsVista.Api.Controllers.V2;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Core.Helpers;
 
@@ -54,6 +55,13 @@ public class PanoramaService : IPanoramaService
         int? solMin = null,
         int? solMax = null,
         int? minPhotos = null,
+        string? stitchStatus = null,
+        string? stitchMethod = null,
+        string? mosaicType = null,
+        string? quality = null,
+        double? minRating = null,
+        string? sort = null,
+        string? order = null,
         int pageNumber = 1,
         int pageSize = 25,
         CancellationToken cancellationToken = default)
@@ -154,8 +162,101 @@ public class PanoramaService : IPanoramaService
             allPanoramas.AddRange(solPanoramas);
         }
 
-        // Use the detected panoramas
-        var panoramas = allPanoramas;
+        // Apply in-memory filters on detected panoramas
+        var filtered = (IEnumerable<PanoramaSequence>)allPanoramas;
+
+        if (!string.IsNullOrWhiteSpace(mosaicType))
+        {
+            var isMr = mosaicType.Equals("multi_row", StringComparison.OrdinalIgnoreCase);
+            filtered = filtered.Where(p => p.IsMultiRow == isMr);
+        }
+
+        if (!string.IsNullOrWhiteSpace(quality))
+        {
+            filtered = filtered.Where(p =>
+            {
+                var azimuths = p.Photos.Select(ph => ph.MastAz ?? 0);
+                var coverage = azimuths.Max() - azimuths.Min();
+                var positions = p.Photos.Select(ph => Math.Round(ph.MastAz ?? 0)).Distinct().Count();
+                return GetQualityTier(coverage, positions).Equals(quality, StringComparison.OrdinalIgnoreCase);
+            });
+        }
+
+        var panoramas = filtered.ToList();
+
+        // Build panorama IDs for all remaining panoramas (needed for stitch/rating filters)
+        var allPanoramaIds = panoramas.Select(p => GetPanoramaId(p)).ToList();
+
+        // Load stitch statuses and ratings for filtering
+        var allStitchStatuses = allPanoramaIds.Count > 0
+            ? await _context.StitchedPanoramas
+                .AsNoTracking()
+                .Where(s => allPanoramaIds.Contains(s.PanoramaId))
+                .ToDictionaryAsync(s => s.PanoramaId, cancellationToken)
+            : new Dictionary<string, StitchedPanorama>();
+
+        var allRatingAggregates = allPanoramaIds.Count > 0
+            ? await _context.PanoramaRatings
+                .AsNoTracking()
+                .Where(r => allPanoramaIds.Contains(r.PanoramaId))
+                .GroupBy(r => r.PanoramaId)
+                .Select(g => new { PanoramaId = g.Key, Avg = g.Average(r => r.Rating), Count = g.Count() })
+                .ToDictionaryAsync(
+                    r => r.PanoramaId,
+                    r => new RatingAggregate(r.Avg, r.Count),
+                    cancellationToken)
+            : new Dictionary<string, RatingAggregate>();
+
+        // Apply stitch/rating filters
+        if (!string.IsNullOrWhiteSpace(stitchStatus))
+        {
+            panoramas = panoramas.Where(p =>
+            {
+                var pid = GetPanoramaId(p);
+                if (stitchStatus.Equals("not_started", StringComparison.OrdinalIgnoreCase))
+                    return !allStitchStatuses.ContainsKey(pid);
+                return allStitchStatuses.TryGetValue(pid, out var s) &&
+                       s.Status.Equals(stitchStatus, StringComparison.OrdinalIgnoreCase);
+            }).ToList();
+        }
+
+        if (!string.IsNullOrWhiteSpace(stitchMethod))
+        {
+            panoramas = panoramas.Where(p =>
+            {
+                var pid = GetPanoramaId(p);
+                return allStitchStatuses.TryGetValue(pid, out var s) &&
+                       s.StitchMethod != null &&
+                       s.StitchMethod.Equals(stitchMethod, StringComparison.OrdinalIgnoreCase);
+            }).ToList();
+        }
+
+        if (minRating.HasValue)
+        {
+            panoramas = panoramas.Where(p =>
+            {
+                var pid = GetPanoramaId(p);
+                return allRatingAggregates.TryGetValue(pid, out var r) && r.Average >= minRating.Value;
+            }).ToList();
+        }
+
+        // Apply sorting
+        var sortField = sort?.ToLowerInvariant() ?? "sol";
+        var isAscending = order?.Equals("asc", StringComparison.OrdinalIgnoreCase) == true;
+
+        panoramas = sortField switch
+        {
+            "rating" => isAscending
+                ? panoramas.OrderBy(p => allRatingAggregates.TryGetValue(GetPanoramaId(p), out var r) ? r.Average : 0).ToList()
+                : panoramas.OrderByDescending(p => allRatingAggregates.TryGetValue(GetPanoramaId(p), out var r) ? r.Average : 0).ToList(),
+            "coverage" => isAscending
+                ? panoramas.OrderBy(p => p.Photos.Select(ph => ph.MastAz ?? 0).Max() - p.Photos.Select(ph => ph.MastAz ?? 0).Min()).ToList()
+                : panoramas.OrderByDescending(p => p.Photos.Select(ph => ph.MastAz ?? 0).Max() - p.Photos.Select(ph => ph.MastAz ?? 0).Min()).ToList(),
+            "photos" => isAscending
+                ? panoramas.OrderBy(p => p.Photos.Count).ToList()
+                : panoramas.OrderByDescending(p => p.Photos.Count).ToList(),
+            _ => panoramas // Default: sol order (already in sol order from detection)
+        };
 
         // Apply pagination
         var totalCount = panoramas.Count;
@@ -164,21 +265,19 @@ public class PanoramaService : IPanoramaService
             .Take(pageSize)
             .ToList();
 
-        // Batch-load stitch statuses to avoid N+1 queries
-        var panoramaIds = paginatedPanoramas.Select(p =>
-        {
-            var first = p.Photos.First();
-            var r = first.Rover.Name.ToLowerInvariant();
-            return $"pano_{r}_{first.Sol}_{p.Index}";
-        }).ToList();
+        // Build stitch/rating dictionaries for just the paginated results
+        var paginatedIds = new HashSet<string>(paginatedPanoramas.Select(p => GetPanoramaId(p)));
 
-        var stitchStatuses = await _context.StitchedPanoramas
-            .AsNoTracking()
-            .Where(s => panoramaIds.Contains(s.PanoramaId) && s.Status == "completed")
-            .ToDictionaryAsync(s => s.PanoramaId, cancellationToken);
+        var stitchStatuses = allStitchStatuses
+            .Where(kv => paginatedIds.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        var ratingAggregates = allRatingAggregates
+            .Where(kv => paginatedIds.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
 
         // Convert to resources
-        var resources = paginatedPanoramas.Select(p => ToPanoramaResource(p, stitchStatuses)).ToList();
+        var resources = paginatedPanoramas.Select(p => ToPanoramaResource(p, stitchStatuses, ratingAggregates: ratingAggregates)).ToList();
 
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
 
@@ -208,10 +307,22 @@ public class PanoramaService : IPanoramaService
 
         var stitchRecord = await _context.StitchedPanoramas
             .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.PanoramaId == panoramaId && s.Status == "completed", cancellationToken);
+            .FirstOrDefaultAsync(s => s.PanoramaId == panoramaId, cancellationToken);
 
         var stitchStatuses = stitchRecord != null
             ? new Dictionary<string, StitchedPanorama> { { panoramaId, stitchRecord } }
+            : null;
+
+        // Load rating aggregate for this panorama
+        var ratingData = await _context.PanoramaRatings
+            .AsNoTracking()
+            .Where(r => r.PanoramaId == panoramaId)
+            .GroupBy(r => r.PanoramaId)
+            .Select(g => new { Avg = g.Average(r => r.Rating), Count = g.Count() })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var ratingAggregates = ratingData != null
+            ? new Dictionary<string, RatingAggregate> { { panoramaId, new RatingAggregate(ratingData.Avg, ratingData.Count) } }
             : null;
 
         // Map constituent photos to PhotoResource for detail response
@@ -225,7 +336,65 @@ public class PanoramaService : IPanoramaService
         };
         var photoResources = await _photoService.GetPhotosByIdsAsync(photoIds, photoParams, cancellationToken);
 
-        return ToPanoramaResource(sequence, stitchStatuses, photoResources);
+        return ToPanoramaResource(sequence, stitchStatuses, photoResources, ratingAggregates);
+    }
+
+    public async Task<RatingResponse> UpsertRatingAsync(
+        string panoramaId,
+        string clientId,
+        int rating,
+        CancellationToken cancellationToken = default)
+    {
+        var existing = await _context.PanoramaRatings
+            .FirstOrDefaultAsync(r => r.PanoramaId == panoramaId && r.ClientId == clientId, cancellationToken);
+
+        if (existing != null)
+        {
+            existing.Rating = rating;
+        }
+        else
+        {
+            _context.PanoramaRatings.Add(new PanoramaRating
+            {
+                PanoramaId = panoramaId,
+                Rating = rating,
+                ClientId = clientId
+            });
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return await GetRatingAsync(panoramaId, clientId, cancellationToken);
+    }
+
+    public async Task<RatingResponse> GetRatingAsync(
+        string panoramaId,
+        string? clientId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var aggregate = await _context.PanoramaRatings
+            .AsNoTracking()
+            .Where(r => r.PanoramaId == panoramaId)
+            .GroupBy(r => r.PanoramaId)
+            .Select(g => new { Avg = g.Average(r => r.Rating), Count = g.Count() })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        int? userRating = null;
+        if (!string.IsNullOrEmpty(clientId))
+        {
+            userRating = await _context.PanoramaRatings
+                .AsNoTracking()
+                .Where(r => r.PanoramaId == panoramaId && r.ClientId == clientId)
+                .Select(r => (int?)r.Rating)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return new RatingResponse
+        {
+            AverageRating = aggregate != null ? Math.Round(aggregate.Avg, 1) : 0,
+            RatingCount = aggregate?.Count ?? 0,
+            UserRating = userRating
+        };
     }
 
     private async Task<PanoramaSequence?> DetectPanoramaSequenceByIdAsync(
@@ -616,7 +785,8 @@ public class PanoramaService : IPanoramaService
     /// </summary>
     private PanoramaResource ToPanoramaResource(PanoramaSequence sequence,
         Dictionary<string, StitchedPanorama>? stitchStatuses = null,
-        List<PhotoResource>? photoResources = null)
+        List<PhotoResource>? photoResources = null,
+        Dictionary<string, RatingAggregate>? ratingAggregates = null)
     {
         var firstPhoto = sequence.Photos.First();
         var lastPhoto = sequence.Photos.Last();
@@ -695,6 +865,26 @@ public class PanoramaService : IPanoramaService
             };
         }
 
+        // Build StitchInfo from stitch status and rating aggregates
+        StitchInfo? stitchInfo = null;
+        StitchedPanorama? stitchRecord = null;
+        stitchStatuses?.TryGetValue(panoramaId, out stitchRecord);
+        RatingAggregate? ratingAgg = null;
+        ratingAggregates?.TryGetValue(panoramaId, out ratingAgg);
+
+        if (stitchRecord != null || ratingAgg != null)
+        {
+            stitchInfo = new StitchInfo
+            {
+                Status = stitchRecord?.Status ?? "not_started",
+                Method = stitchRecord?.StitchMethod,
+                Width = stitchRecord?.Status == "completed" ? stitchRecord.ImageWidth : null,
+                Height = stitchRecord?.Status == "completed" ? stitchRecord.ImageHeight : null,
+                AverageRating = ratingAgg != null ? Math.Round(ratingAgg.Average, 1) : null,
+                RatingCount = ratingAgg?.Count
+            };
+        }
+
         return new PanoramaResource
         {
             Id = panoramaId,
@@ -724,16 +914,26 @@ public class PanoramaService : IPanoramaService
                     : null,
                 VerticalCoverageDegrees = sequence.IsMultiRow
                     ? sequence.MaxElevation - sequence.MinElevation
-                    : null
+                    : null,
+                Stitch = stitchInfo
             },
             Links = new PanoramaLinks
             {
-                StitchedPreview = stitchStatuses != null && stitchStatuses.ContainsKey(panoramaId)
+                StitchedPreview = stitchRecord?.Status == "completed"
                     ? $"/stitch/{panoramaId}/image"
                     : null,
                 DownloadSet = $"/api/v2/panoramas/{panoramaId}/download"
             }
         };
+    }
+
+    /// <summary>
+    /// Get panorama ID string from a sequence
+    /// </summary>
+    private static string GetPanoramaId(PanoramaSequence sequence)
+    {
+        var first = sequence.Photos.First();
+        return $"pano_{first.Rover.Name.ToLowerInvariant()}_{first.Sol}_{sequence.Index}";
     }
 
     /// <summary>
@@ -760,4 +960,9 @@ public class PanoramaService : IPanoramaService
         public float MinElevation { get; set; }
         public float MaxElevation { get; set; }
     }
+
+    /// <summary>
+    /// Rating aggregate for a panorama
+    /// </summary>
+    private record RatingAggregate(double Average, int Count);
 }

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using MarsVista.Core.Data;
 using MarsVista.Core.Entities;
-using MarsVista.Api.Controllers.V2;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Core.Helpers;
 
@@ -866,24 +865,21 @@ public class PanoramaService : IPanoramaService
         }
 
         // Build StitchInfo from stitch status and rating aggregates
-        StitchInfo? stitchInfo = null;
+        // Always include StitchInfo for consistent API responses (never null)
         StitchedPanorama? stitchRecord = null;
         stitchStatuses?.TryGetValue(panoramaId, out stitchRecord);
         RatingAggregate? ratingAgg = null;
         ratingAggregates?.TryGetValue(panoramaId, out ratingAgg);
 
-        if (stitchRecord != null || ratingAgg != null)
+        var stitchInfo = new StitchInfo
         {
-            stitchInfo = new StitchInfo
-            {
-                Status = stitchRecord?.Status ?? "not_started",
-                Method = stitchRecord?.StitchMethod,
-                Width = stitchRecord?.Status == "completed" ? stitchRecord.ImageWidth : null,
-                Height = stitchRecord?.Status == "completed" ? stitchRecord.ImageHeight : null,
-                AverageRating = ratingAgg != null ? Math.Round(ratingAgg.Average, 1) : null,
-                RatingCount = ratingAgg?.Count
-            };
-        }
+            Status = stitchRecord?.Status ?? "not_started",
+            Method = stitchRecord?.StitchMethod,
+            Width = stitchRecord?.Status == "completed" ? stitchRecord.ImageWidth : null,
+            Height = stitchRecord?.Status == "completed" ? stitchRecord.ImageHeight : null,
+            AverageRating = ratingAgg != null ? Math.Round(ratingAgg.Average, 1) : null,
+            RatingCount = ratingAgg?.Count
+        };
 
         return new PanoramaResource
         {

--- a/src/MarsVista.Core/Data/MarsVistaDbContext.cs
+++ b/src/MarsVista.Core/Data/MarsVistaDbContext.cs
@@ -23,6 +23,7 @@ public class MarsVistaDbContext : DbContext
     public DbSet<RoverWaypoint> RoverWaypoints { get; set; }
     public DbSet<SolCompleteness> SolCompleteness { get; set; }
     public DbSet<StitchedPanorama> StitchedPanoramas { get; set; }
+    public DbSet<PanoramaRating> PanoramaRatings { get; set; }
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
@@ -320,8 +321,30 @@ public class MarsVistaDbContext : DbContext
             entity.Property(e => e.PanoramaId).HasMaxLength(100).IsRequired();
             entity.Property(e => e.Status).HasMaxLength(20).IsRequired()
                 .HasDefaultValue("processing");
+            entity.Property(e => e.StitchMethod).HasMaxLength(30);
             entity.Property(e => e.ImagePath).HasMaxLength(500);
             entity.Property(e => e.ErrorMessage).HasMaxLength(2000);
+
+            entity.Property(e => e.CreatedAt)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        // PanoramaRating configuration
+        modelBuilder.Entity<PanoramaRating>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id)
+                .HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.PanoramaId).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Rating).IsRequired();
+            entity.Property(e => e.ClientId).HasMaxLength(100).IsRequired();
+
+            // One rating per panorama per client
+            entity.HasIndex(e => new { e.PanoramaId, e.ClientId }).IsUnique();
+
+            // Fast lookup by panorama for aggregate queries
+            entity.HasIndex(e => e.PanoramaId);
 
             entity.Property(e => e.CreatedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP");

--- a/src/MarsVista.Core/Data/Migrations/20260223134418_AddStitchMethodAndRatings.Designer.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260223134418_AddStitchMethodAndRatings.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using MarsVista.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MarsVista.Core.Data.Migrations
 {
     [DbContext(typeof(MarsVistaDbContext))]
-    partial class MarsVistaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260223134418_AddStitchMethodAndRatings")]
+    partial class AddStitchMethodAndRatings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MarsVista.Core/Data/Migrations/20260223134418_AddStitchMethodAndRatings.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260223134418_AddStitchMethodAndRatings.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MarsVista.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStitchMethodAndRatings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "stitch_method",
+                table: "stitched_panoramas",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "panorama_ratings",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    panorama_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    rating = table.Column<int>(type: "integer", nullable: false),
+                    client_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_panorama_ratings", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panorama_ratings_panorama_id",
+                table: "panorama_ratings",
+                column: "panorama_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panorama_ratings_panorama_id_client_id",
+                table: "panorama_ratings",
+                columns: new[] { "panorama_id", "client_id" },
+                unique: true);
+
+            migrationBuilder.Sql(
+                "ALTER TABLE panorama_ratings ADD CONSTRAINT chk_panorama_ratings_rating CHECK (rating BETWEEN 1 AND 5)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "ALTER TABLE panorama_ratings DROP CONSTRAINT IF EXISTS chk_panorama_ratings_rating");
+
+            migrationBuilder.DropTable(
+                name: "panorama_ratings");
+
+            migrationBuilder.DropColumn(
+                name: "stitch_method",
+                table: "stitched_panoramas");
+        }
+    }
+}

--- a/src/MarsVista.Core/Entities/PanoramaRating.cs
+++ b/src/MarsVista.Core/Entities/PanoramaRating.cs
@@ -1,0 +1,10 @@
+namespace MarsVista.Core.Entities;
+
+public class PanoramaRating
+{
+    public Guid Id { get; set; }
+    public string PanoramaId { get; set; } = string.Empty;
+    public int Rating { get; set; } // 1-5
+    public string ClientId { get; set; } = string.Empty; // API key hash
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/MarsVista.Core/Entities/StitchedPanorama.cs
+++ b/src/MarsVista.Core/Entities/StitchedPanorama.cs
@@ -5,6 +5,7 @@ public class StitchedPanorama
     public Guid Id { get; set; }
     public string PanoramaId { get; set; } = string.Empty;
     public string Status { get; set; } = "processing"; // processing, completed, failed
+    public string? StitchMethod { get; set; } // feature_match, telemetry_projection
     public string? ImagePath { get; set; }
     public int? ImageWidth { get; set; }
     public int? ImageHeight { get; set; }

--- a/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
+++ b/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
@@ -1,0 +1,388 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MarsVista.Core.Entities;
+using MarsVista.Api.Services.V2;
+using MarsVista.Api.Tests.Integration;
+
+namespace MarsVista.Api.Tests.Services.V2;
+
+public class PanoramaFilterAndRatingTests : IntegrationTestBase
+{
+    private Mock<ILogger<PanoramaService>> _mockLogger = null!;
+    private Mock<IPhotoQueryServiceV2> _mockPhotoService = null!;
+    private PanoramaService _service = null!;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _mockLogger = new Mock<ILogger<PanoramaService>>();
+        _mockPhotoService = new Mock<IPhotoQueryServiceV2>();
+
+        services.AddSingleton(_mockLogger.Object);
+        services.AddSingleton(_mockPhotoService.Object);
+        services.AddScoped<PanoramaService>();
+    }
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        _service = ServiceProvider.GetRequiredService<PanoramaService>();
+
+        var now = DateTime.UtcNow;
+
+        // Panorama 1: Sol 1900, 5 photos, ~40° coverage (quality: "partial", single_row)
+        // Using sol 1900 (not 1000) to stay within DefaultSolRangeLimit=500 of sol 2000
+        for (int i = 0; i < 5; i++)
+        {
+            DbContext.Photos.Add(new Photo
+            {
+                NasaId = $"NRF_1900_{i:D4}",
+                Sol = 1900,
+                EarthDate = new DateTime(2015, 5, 30, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 5, 30, 10, i, 0, DateTimeKind.Utc),
+                ImgSrcFull = $"https://mars.nasa.gov/photo{i}_f.jpg",
+                Site = 79,
+                Drive = 1204,
+                MastAz = 45.0f + (i * 10.0f), // 45-85°, 40° range
+                MastEl = -10.0f,
+                SpacecraftClock = 813073000.0f + (i * 100.0f),
+                RoverId = 1,
+                CameraId = 2, // MAST
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+
+        // Panorama 2: Sol 2000, 12 photos, ~220° coverage (quality: "wide", single_row)
+        for (int i = 0; i < 12; i++)
+        {
+            DbContext.Photos.Add(new Photo
+            {
+                NasaId = $"NRF_2000_{i:D4}",
+                Sol = 2000,
+                EarthDate = new DateTime(2016, 3, 15, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2016, 3, 15, 10, i, 0, DateTimeKind.Utc),
+                ImgSrcFull = $"https://mars.nasa.gov/photo2k{i}_f.jpg",
+                Site = 80,
+                Drive = 1300,
+                MastAz = 10.0f + (i * 20.0f), // 10-230°, 220° range
+                MastEl = -5.0f,
+                SpacecraftClock = 913073000.0f + (i * 100.0f),
+                RoverId = 1,
+                CameraId = 2,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+
+        await DbContext.SaveChangesAsync();
+
+        // Add stitch records for panorama 2 (completed with feature_match)
+        DbContext.StitchedPanoramas.Add(new StitchedPanorama
+        {
+            PanoramaId = "pano_curiosity_2000_0",
+            Status = "completed",
+            StitchMethod = "feature_match",
+            ImageWidth = 8519,
+            ImageHeight = 2322,
+            ImageSizeBytes = 1234567,
+            SourcePhotoCount = 12,
+            CreatedAt = now,
+            CompletedAt = now
+        });
+
+        // Add stitch record for panorama 1 (failed)
+        DbContext.StitchedPanoramas.Add(new StitchedPanorama
+        {
+            PanoramaId = "pano_curiosity_1900_0",
+            Status = "failed",
+            ErrorMessage = "Not enough overlap",
+            CreatedAt = now,
+            CompletedAt = now
+        });
+
+        // Add ratings for panorama 2
+        DbContext.PanoramaRatings.Add(new PanoramaRating
+        {
+            PanoramaId = "pano_curiosity_2000_0",
+            Rating = 5,
+            ClientId = "client_a",
+            CreatedAt = now
+        });
+        DbContext.PanoramaRatings.Add(new PanoramaRating
+        {
+            PanoramaId = "pano_curiosity_2000_0",
+            Rating = 3,
+            ClientId = "client_b",
+            CreatedAt = now
+        });
+
+        await DbContext.SaveChangesAsync();
+    }
+
+    // -- Stitch status filter tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_StitchStatusCompleted_FiltersToStitchedOnly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            stitchStatus: "completed",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(2000);
+        result.Data[0].Attributes.Stitch.Should().NotBeNull();
+        result.Data[0].Attributes.Stitch!.Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_StitchStatusFailed_FiltersToFailedOnly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            stitchStatus: "failed",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(1900);
+        result.Data[0].Attributes.Stitch.Should().NotBeNull();
+        result.Data[0].Attributes.Stitch!.Status.Should().Be("failed");
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_StitchStatusNotStarted_ExcludesStitched()
+    {
+        // Both panoramas have stitch records, so not_started should return empty
+        var result = await _service.GetPanoramasAsync(
+            stitchStatus: "not_started",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().BeEmpty();
+    }
+
+    // -- Stitch method filter tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_StitchMethodFeatureMatch_FiltersCorrectly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            stitchMethod: "feature_match",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(2000);
+        result.Data[0].Attributes.Stitch!.Method.Should().Be("feature_match");
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_StitchMethodTelemetryProjection_ReturnsEmpty()
+    {
+        var result = await _service.GetPanoramasAsync(
+            stitchMethod: "telemetry_projection",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().BeEmpty();
+    }
+
+    // -- Quality filter tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_QualityWide_FiltersCorrectly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            quality: "wide",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(2000);
+        result.Data[0].Attributes.Quality.Should().Be("wide");
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_QualityPartial_FiltersCorrectly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            quality: "partial",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(1900);
+        result.Data[0].Attributes.Quality.Should().Be("partial");
+    }
+
+    // -- Mosaic type filter tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_MosaicTypeSingleRow_FiltersCorrectly()
+    {
+        var result = await _service.GetPanoramasAsync(
+            mosaicType: "single_row",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(2);
+        result.Data.Should().OnlyContain(p => p.Attributes.MosaicType == "single_row");
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_MosaicTypeMultiRow_ReturnsEmpty()
+    {
+        var result = await _service.GetPanoramasAsync(
+            mosaicType: "multi_row",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().BeEmpty();
+    }
+
+    // -- Min rating filter tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_MinRating4_FiltersToHighRatedOnly()
+    {
+        // Panorama 2 has ratings 5+3=8/2=4.0 avg
+        var result = await _service.GetPanoramasAsync(
+            minRating: 4.0,
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Attributes.Sol.Should().Be(2000);
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_MinRating5_ReturnsEmpty()
+    {
+        // Average is 4.0, so min_rating=5 excludes everything
+        var result = await _service.GetPanoramasAsync(
+            minRating: 5.0,
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().BeEmpty();
+    }
+
+    // -- Sort tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_SortByPhotosDesc_HighestFirst()
+    {
+        var result = await _service.GetPanoramasAsync(
+            sort: "photos",
+            order: "desc",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCountGreaterThanOrEqualTo(2);
+        result.Data[0].Attributes.TotalPhotos.Should()
+            .BeGreaterThanOrEqualTo(result.Data[1].Attributes.TotalPhotos);
+    }
+
+    [Fact]
+    public async Task GetPanoramasAsync_SortByPhotosAsc_LowestFirst()
+    {
+        var result = await _service.GetPanoramasAsync(
+            sort: "photos",
+            order: "asc",
+            pageNumber: 1,
+            pageSize: 25);
+
+        result.Data.Should().HaveCountGreaterThanOrEqualTo(2);
+        result.Data[0].Attributes.TotalPhotos.Should()
+            .BeLessThanOrEqualTo(result.Data[1].Attributes.TotalPhotos);
+    }
+
+    // -- StitchInfo in response tests --
+
+    [Fact]
+    public async Task GetPanoramasAsync_CompletedStitch_IncludesStitchInfo()
+    {
+        var result = await _service.GetPanoramasAsync(
+            stitchStatus: "completed",
+            pageNumber: 1,
+            pageSize: 25);
+
+        var panorama = result.Data.First();
+        panorama.Attributes.Stitch.Should().NotBeNull();
+        panorama.Attributes.Stitch!.Status.Should().Be("completed");
+        panorama.Attributes.Stitch.Method.Should().Be("feature_match");
+        panorama.Attributes.Stitch.Width.Should().Be(8519);
+        panorama.Attributes.Stitch.Height.Should().Be(2322);
+        panorama.Attributes.Stitch.AverageRating.Should().Be(4.0);
+        panorama.Attributes.Stitch.RatingCount.Should().Be(2);
+    }
+
+    // -- Rating endpoint tests --
+
+    [Fact]
+    public async Task UpsertRatingAsync_CreatesNewRating()
+    {
+        var result = await _service.UpsertRatingAsync("pano_curiosity_1900_0", "new_client", 4);
+
+        result.AverageRating.Should().Be(4.0);
+        result.RatingCount.Should().Be(1);
+        result.UserRating.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task UpsertRatingAsync_UpdatesExistingRating()
+    {
+        // First rating
+        await _service.UpsertRatingAsync("pano_test_999_0", "test_client", 2);
+
+        // Update rating
+        var result = await _service.UpsertRatingAsync("pano_test_999_0", "test_client", 5);
+
+        result.AverageRating.Should().Be(5.0); // Updated, not averaged with old
+        result.RatingCount.Should().Be(1); // Still one rating
+        result.UserRating.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task UpsertRatingAsync_MultipleClients_AveragesCorrectly()
+    {
+        await _service.UpsertRatingAsync("pano_test_888_0", "client_1", 5);
+        var result = await _service.UpsertRatingAsync("pano_test_888_0", "client_2", 3);
+
+        result.AverageRating.Should().Be(4.0);
+        result.RatingCount.Should().Be(2);
+        result.UserRating.Should().Be(3); // client_2's rating
+    }
+
+    [Fact]
+    public async Task GetRatingAsync_WithClientId_IncludesUserRating()
+    {
+        // Panorama 2 was seeded with ratings from client_a (5) and client_b (3)
+        var result = await _service.GetRatingAsync("pano_curiosity_2000_0", "client_a");
+
+        result.AverageRating.Should().Be(4.0);
+        result.RatingCount.Should().Be(2);
+        result.UserRating.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetRatingAsync_WithoutClientId_OmitsUserRating()
+    {
+        var result = await _service.GetRatingAsync("pano_curiosity_2000_0");
+
+        result.AverageRating.Should().Be(4.0);
+        result.RatingCount.Should().Be(2);
+        result.UserRating.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetRatingAsync_NoRatings_ReturnsZeros()
+    {
+        var result = await _service.GetRatingAsync("pano_no_ratings_0");
+
+        result.AverageRating.Should().Be(0);
+        result.RatingCount.Should().Be(0);
+        result.UserRating.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Implements Story 050: panorama stitch method metadata, filtering, and user ratings.

**Stitch method tracking**: Record which algorithm (feature_match or telemetry_projection) produced each panorama stitch, surfaced in both the stitch service response and the API panorama resource.

**Panorama filtering/sorting**: Add 7 new query parameters to `GET /api/v2/panoramas` — filter by stitch status, stitch method, mosaic type, quality tier, minimum rating, and sort by sol/rating/coverage/photos.

**User ratings**: Let users rate panorama quality (1-5 stars) with per-API-key deduplication and upsert support.

## Changes
- Add `stitch_method` column to `stitched_panoramas` table
- Create `panorama_ratings` table with CHECK constraint and unique per-client index
- Add `StitchInfo` DTO with status, method, dimensions, average_rating, rating_count
- Add stitch info to `PanoramaAttributes` (loaded for all panoramas, not just completed)
- Add filter params: stitch_status, stitch_method, mosaic_type, quality, min_rating, sort, order
- Add `POST /api/v2/panoramas/{id}/rating` and `GET /api/v2/panoramas/{id}/rating` endpoints
- 20 new integration tests covering filters, sorting, ratings CRUD, and deduplication

## Related
- Companion PR in mars-vista-stitch: stitch method tracking (feature/stitch-method-tracking)
- Story: `.claude/stories/050-2026-02-23-panorama-stitch-metadata-and-ratings.md`

## Testing
- [x] All 266 API tests pass (including 20 new)
- [x] All 163 scraper tests pass
- [x] Build succeeds with 0 errors

## Notes for Reviewers
- Migration auto-runs on startup, will add column + table to production DB on deploy
- Existing stitch records will have NULL stitch_method (option 1 from story — backfill later)
- Rating uses ApiKeyId (Guid) as client_id rather than raw key hash (already in HttpContext.Items)