### PR TITLE
Fix rating filters running correlated subquery per photo

### DIFF
--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -610,16 +610,29 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
             query = query.Where(p => p.MastAz.HasValue && p.MastAz.Value <= parameters.MastAzimuthMax.Value);
         }
 
-        // Filter by rating
+        // Filter by rating - pre-aggregate qualifying photo_ids in a single subquery
+        // (HashAggregate over photo_ratings) instead of the correlated form
+        // `p.Ratings.Average(...) >= X`, which EF Core translates to a per-row
+        // subquery executed once per photo in the outer query. With 1.58M photos
+        // that was ~5.5 s and ~23 GB of buffer reads to return zero rows.
         if (parameters.MinRating.HasValue)
         {
-            query = query.Where(p => p.Ratings.Any() &&
-                p.Ratings.Average(r => (double)r.Rating) >= parameters.MinRating.Value);
+            var minRating = parameters.MinRating.Value;
+            var qualifyingByRating = _context.PhotoRatings
+                .GroupBy(r => r.PhotoId)
+                .Where(g => g.Average(r => (double)r.Rating) >= minRating)
+                .Select(g => g.Key);
+            query = query.Where(p => qualifyingByRating.Contains(p.Id));
         }
 
         if (parameters.MinRatingCount.HasValue)
         {
-            query = query.Where(p => p.Ratings.Count() >= parameters.MinRatingCount.Value);
+            var minCount = parameters.MinRatingCount.Value;
+            var qualifyingByCount = _context.PhotoRatings
+                .GroupBy(r => r.PhotoId)
+                .Where(g => g.Count() >= minCount)
+                .Select(g => g.Key);
+            query = query.Where(p => qualifyingByCount.Contains(p.Id));
         }
 
         return query;

--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -667,6 +667,12 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
                     "date_taken_utc" => isDescending ? query.OrderByDescending(p => p.DateTakenUtc) : query.OrderBy(p => p.DateTakenUtc),
                     "camera" => isDescending ? query.OrderByDescending(p => p.Camera.Name) : query.OrderBy(p => p.Camera.Name),
                     "created_at" => isDescending ? query.OrderByDescending(p => p.CreatedAt) : query.OrderBy(p => p.CreatedAt),
+                    // TODO: same correlated-aggregate antipattern as the
+                    // rating filter above - p.Ratings.Average / .Count
+                    // compiles to a per-row subquery. Tolerable today because
+                    // photo_ratings has < 100 rows and no current traffic
+                    // uses sort=rating. Rewrite via a projected join when
+                    // the table grows.
                     "rating" => isDescending
                         ? query.OrderByDescending(p => p.Ratings.Average(r => (double?)r.Rating) ?? 0)
                         : query.OrderBy(p => p.Ratings.Any()
@@ -688,6 +694,8 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
                     "date_taken_utc" => isDescending ? orderedQuery.ThenByDescending(p => p.DateTakenUtc) : orderedQuery.ThenBy(p => p.DateTakenUtc),
                     "camera" => isDescending ? orderedQuery.ThenByDescending(p => p.Camera.Name) : orderedQuery.ThenBy(p => p.Camera.Name),
                     "created_at" => isDescending ? orderedQuery.ThenByDescending(p => p.CreatedAt) : orderedQuery.ThenBy(p => p.CreatedAt),
+                    // TODO: same correlated-aggregate antipattern as the
+                    // primary-sort branch above - see note there.
                     "rating" => isDescending
                         ? orderedQuery.ThenByDescending(p => p.Ratings.Average(r => (double?)r.Rating) ?? 0)
                         : orderedQuery.ThenBy(p => p.Ratings.Any()

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -255,8 +255,10 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
 
         var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
 
-        // Correctness: only p2 (2 ratings) qualifies, p1 (0 ratings) and the
-        // sql-generation-seed photos do not.
+        // Correctness: only p2 (2 ratings) qualifies. p1 (0 ratings) and the
+        // three base-seed photos (Q-CUR-FHAZ, Q-PER-NAVCAM, Q-PER-FHAZ - see
+        // SeedAdditionalDataAsync above) have no photo_ratings rows so they
+        // do not appear in the GroupBy result the subquery filters on.
         response.Data.Should().ContainSingle();
         response.Data.Single().Attributes!.NasaId.Should().Be("R-TWO-RATINGS");
 
@@ -310,6 +312,9 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
 
         // Correctness: only pHigh (avg 5) qualifies; pLow (avg 2) does not.
+        // The three base-seed photos (Q-CUR-FHAZ, Q-PER-NAVCAM, Q-PER-FHAZ -
+        // see SeedAdditionalDataAsync above) have no photo_ratings rows so
+        // they are excluded by the GroupBy subquery.
         response.Data.Should().ContainSingle();
         response.Data.Single().Attributes!.NasaId.Should().Be("AVG-HIGH");
 

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -213,4 +213,114 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         // which returns an empty result instead of trying to translate the unknown name.
         response.Meta!.TotalCount.Should().Be(0);
     }
+
+    [Fact]
+    public async Task MinRatingCountFilter_EmitsAggregatedSubquery_NotCorrelated()
+    {
+        // Seed two photos and two ratings on the second so a min_rating_count=2
+        // filter can return exactly one. The same data lets us verify that the
+        // generated SQL uses GROUP BY photo_id once, not a per-row correlated
+        // subquery (which previously caused a 5.5 s / 23 GB scan on production).
+        var now = DateTime.UtcNow;
+        var p1 = new Photo
+        {
+            NasaId = "R-NO-RATINGS", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+            Sol = 10, EarthDate = new DateTime(2013, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            DateTakenUtc = new DateTime(2013, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            SampleType = "Full", RoverId = 1, CameraId = 1,
+            CreatedAt = now, UpdatedAt = now,
+        };
+        var p2 = new Photo
+        {
+            NasaId = "R-TWO-RATINGS", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+            Sol = 11, EarthDate = new DateTime(2013, 5, 2, 0, 0, 0, DateTimeKind.Utc),
+            DateTakenUtc = new DateTime(2013, 5, 2, 0, 0, 0, DateTimeKind.Utc),
+            SampleType = "Full", RoverId = 1, CameraId = 1,
+            CreatedAt = now, UpdatedAt = now,
+        };
+        DbContext.Photos.AddRange(p1, p2);
+        await DbContext.SaveChangesAsync();
+        DbContext.PhotoRatings.AddRange(
+            new PhotoRating { PhotoId = p2.Id, Rating = 4, ClientId = "client-a", CreatedAt = now, UpdatedAt = now },
+            new PhotoRating { PhotoId = p2.Id, Rating = 5, ClientId = "client-b", CreatedAt = now, UpdatedAt = now });
+        await DbContext.SaveChangesAsync();
+
+        SqlCapture.Clear();
+
+        var parameters = new PhotoQueryParameters
+        {
+            MinRatingCount = 2,
+            Page = 1, PerPage = 10,
+        };
+
+        var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        // Correctness: only p2 (2 ratings) qualifies, p1 (0 ratings) and the
+        // sql-generation-seed photos do not.
+        response.Data.Should().ContainSingle();
+        response.Data.Single().Attributes!.NasaId.Should().Be("R-TWO-RATINGS");
+
+        // SQL shape: the predicate must aggregate once, not per outer row.
+        var ratingSqls = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("photo_ratings", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        ratingSqls.Should().NotBeEmpty();
+        foreach (var sql in ratingSqls)
+        {
+            sql.Should().Contain("GROUP BY",
+                "MinRatingCount must compile to an aggregated subquery, not a correlated per-row COUNT");
+        }
+    }
+
+    [Fact]
+    public async Task MinRatingFilter_EmitsAggregatedSubquery_NotCorrelated()
+    {
+        var now = DateTime.UtcNow;
+        var pLow = new Photo
+        {
+            NasaId = "AVG-LOW", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+            Sol = 20, EarthDate = new DateTime(2013, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            DateTakenUtc = new DateTime(2013, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            SampleType = "Full", RoverId = 1, CameraId = 1,
+            CreatedAt = now, UpdatedAt = now,
+        };
+        var pHigh = new Photo
+        {
+            NasaId = "AVG-HIGH", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+            Sol = 21, EarthDate = new DateTime(2013, 6, 2, 0, 0, 0, DateTimeKind.Utc),
+            DateTakenUtc = new DateTime(2013, 6, 2, 0, 0, 0, DateTimeKind.Utc),
+            SampleType = "Full", RoverId = 1, CameraId = 1,
+            CreatedAt = now, UpdatedAt = now,
+        };
+        DbContext.Photos.AddRange(pLow, pHigh);
+        await DbContext.SaveChangesAsync();
+        DbContext.PhotoRatings.AddRange(
+            new PhotoRating { PhotoId = pLow.Id,  Rating = 2, ClientId = "c1", CreatedAt = now, UpdatedAt = now },
+            new PhotoRating { PhotoId = pHigh.Id, Rating = 5, ClientId = "c2", CreatedAt = now, UpdatedAt = now });
+        await DbContext.SaveChangesAsync();
+
+        SqlCapture.Clear();
+
+        var parameters = new PhotoQueryParameters
+        {
+            MinRating = 4.0,
+            Page = 1, PerPage = 10,
+        };
+
+        var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        // Correctness: only pHigh (avg 5) qualifies; pLow (avg 2) does not.
+        response.Data.Should().ContainSingle();
+        response.Data.Single().Attributes!.NasaId.Should().Be("AVG-HIGH");
+
+        var ratingSqls = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("photo_ratings", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        ratingSqls.Should().NotBeEmpty();
+        foreach (var sql in ratingSqls)
+        {
+            sql.Should().Contain("GROUP BY",
+                "MinRating must compile to an aggregated subquery, not a correlated per-row AVG");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`/api/v2/photos?min_rating_count=10&include=rover,camera` hit **59 seconds** in production yesterday (logged as the slowest single request in the 24-hour window). Root cause: EF Core's translation of `Where(p => p.Ratings.Count() >= n)` and `Where(p => p.Ratings.Average(r => r.Rating) >= n)` to a **per-row correlated subquery**, executed once for each of the 1.58M photos in the outer query.

This PR rewrites both filters to **pre-aggregate** qualifying `photo_id`s in a single subquery, so the aggregation runs once total.

## Production EXPLAIN ANALYZE — before vs after

Query: `min_rating_count >= 10`, no other filters, `LIMIT 24`, `ORDER BY date_taken_utc DESC`. Only 3 ratings exist in production, so the result set is empty either way.

| Form | Time | Buffer pages | Notes |
|---|---|---|---|
| **Before** (`p.Ratings.Count() >= 10`) | **5,561 ms** | **2,941,877** (~23 GB) | SubPlan invoked 1,589,690 times |
| **After** (aggregated subquery) | **0.131 ms** | **4** (~32 KB) | HashAggregate runs once over 3 rows |

42,000× faster, ~720,000× less buffer pressure on this query alone.

## What changed

```csharp
// Before:
if (parameters.MinRatingCount.HasValue)
{
    query = query.Where(p => p.Ratings.Count() >= parameters.MinRatingCount.Value);
}

// After:
if (parameters.MinRatingCount.HasValue)
{
    var minCount = parameters.MinRatingCount.Value;
    var qualifyingByCount = _context.PhotoRatings
        .GroupBy(r => r.PhotoId)
        .Where(g => g.Count() >= minCount)
        .Select(g => g.Key);
    query = query.Where(p => qualifyingByCount.Contains(p.Id));
}
```

Same shape for `MinRating` (uses `g.Average(...)` instead of `g.Count()`). EF Core composes the inner `GroupBy/Where/Select` as a single subquery in the outer SQL, so aggregation runs once.

The original `MinRating` clause's `p.Ratings.Any()` pre-check is no longer needed — a photo with no ratings never appears in the `GroupBy` result, so `Contains` filters it out naturally.

## Tests

Two new tests in `PhotoQuerySqlGenerationTests`:

- `MinRatingCountFilter_EmitsAggregatedSubquery_NotCorrelated` — seeds two photos (one with 0 ratings, one with 2 ratings), requests `min_rating_count=2`, asserts only the two-rating photo is returned **and** that the captured SQL hitting `photo_ratings` contains `GROUP BY`.
- `MinRatingFilter_EmitsAggregatedSubquery_NotCorrelated` — same shape for the average-rating filter.

Both use `SqlCapturingInterceptor` to assert on the actual emitted SQL, so a future regression to the correlated form fails CI here.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — **443/443 passing** (163 scraper + 280 api, includes the 2 new rating tests)
- [x] Production read-only EXPLAIN ANALYZE — verified the new plan uses HashAggregate
- [ ] Post-merge: confirm the slow-call pattern in `usage_events` stops appearing for `/api/v2/photos?...&min_rating_count=...`

## Rollback

Standard `git revert`. One file of behaviour change (`PhotoQueryServiceV2.cs`) + one test file. No DB migration, no DI changes, no public contract change.

## Out of scope

The sort-by-rating paths (`sort=rating`, `sort=rating_count`) further down the same file use the same correlated-aggregate antipattern. Fixing those requires a JOIN-shaped rewrite (the sort key has to be projected per row) that is meaningfully bigger. Flagged in the commit message as a follow-up; current production traffic does not appear to use those sort fields.