### PR TITLE
Cache pagination counts in two-level cache

### DIFF
--- a/src/MarsVista.Api/Program.cs
+++ b/src/MarsVista.Api/Program.cs
@@ -187,6 +187,7 @@ builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IPhotoQueryServiceV2, MarsVista.Api.Services.V2.PhotoQueryServiceV2>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IRoverQueryServiceV2, MarsVista.Api.Services.V2.RoverQueryServiceV2>();
 builder.Services.AddSingleton<MarsVista.Api.Services.V2.ICachingServiceV2, MarsVista.Api.Services.V2.CachingServiceV2>();
+builder.Services.AddScoped<MarsVista.Api.Services.V2.IQueryCountCache, MarsVista.Api.Services.V2.QueryCountCache>();
 
 // Cache warming and metrics services
 builder.Services.Configure<MarsVista.Api.Services.V2.CacheWarmingOptions>(

--- a/src/MarsVista.Api/Services/PhotoQueryService.cs
+++ b/src/MarsVista.Api/Services/PhotoQueryService.cs
@@ -1,5 +1,6 @@
 using MarsVista.Core.Data;
 using MarsVista.Api.DTOs;
+using MarsVista.Api.Services.V2;
 using Microsoft.EntityFrameworkCore;
 
 namespace MarsVista.Api.Services;
@@ -9,15 +10,18 @@ public class PhotoQueryService : IPhotoQueryService
     private readonly MarsVistaDbContext _context;
     private readonly ILogger<PhotoQueryService> _logger;
     private readonly IStaticReferenceCache _referenceCache;
+    private readonly IQueryCountCache _countCache;
 
     public PhotoQueryService(
         MarsVistaDbContext context,
         ILogger<PhotoQueryService> logger,
-        IStaticReferenceCache referenceCache)
+        IStaticReferenceCache referenceCache,
+        IQueryCountCache countCache)
     {
         _context = context;
         _logger = logger;
         _referenceCache = referenceCache;
+        _countCache = countCache;
     }
 
     public async Task<(List<PhotoDto> Photos, int TotalCount)> QueryPhotosAsync(
@@ -89,8 +93,8 @@ public class PhotoQueryService : IPhotoQueryService
             }
         }
 
-        // Get total count before pagination
-        var totalCount = await query.CountAsync(cancellationToken);
+        // Get total count before pagination (cached; see IQueryCountCache)
+        var totalCount = await _countCache.GetOrSetCountAsync(query, cancellationToken);
 
         // Order by camera and ID for consistent results, then apply pagination and projection
         // By removing Include() and going straight to Select(), we only fetch the columns we need

--- a/src/MarsVista.Api/Services/RoverQueryService.cs
+++ b/src/MarsVista.Api/Services/RoverQueryService.cs
@@ -11,15 +11,18 @@ public class RoverQueryService : IRoverQueryService
     private readonly MarsVistaDbContext _context;
     private readonly ICachingServiceV2 _cachingService;
     private readonly ILogger<RoverQueryService> _logger;
+    private readonly IQueryCountCache _countCache;
 
     public RoverQueryService(
         MarsVistaDbContext context,
         ICachingServiceV2 cachingService,
-        ILogger<RoverQueryService> logger)
+        ILogger<RoverQueryService> logger,
+        IQueryCountCache countCache)
     {
         _context = context;
         _cachingService = cachingService;
         _logger = logger;
+        _countCache = countCache;
     }
 
     public async Task<List<RoverDto>> GetAllRoversAsync(CancellationToken cancellationToken = default)
@@ -164,8 +167,11 @@ public class RoverQueryService : IRoverQueryService
             return null;
         }
 
-        // Photo count in cache key enables auto-invalidation when new photos are scraped
-        var photoCount = await _context.Photos.CountAsync(p => p.RoverId == rover.Id, cancellationToken);
+        // Photo count in cache key enables auto-invalidation when new photos are scraped.
+        // The count itself is served from the count cache (1 h TTL), so the manifest key
+        // rotates within an hour of the daily scrape without a COUNT(*) per request.
+        var photoCount = await _countCache.GetOrSetCountAsync(
+            _context.Photos.Where(p => p.RoverId == rover.Id), cancellationToken);
         var isActiveRover = rover.Status?.ToLowerInvariant() == "active";
         var cacheKey = _cachingService.GenerateCacheKey("v1", "manifest", normalizedName, photoCount);
 

--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -17,15 +17,18 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
     private readonly MarsVistaDbContext _context;
     private readonly ILogger<PhotoQueryServiceV2> _logger;
     private readonly IStaticReferenceCache _referenceCache;
+    private readonly IQueryCountCache _countCache;
 
     public PhotoQueryServiceV2(
         MarsVistaDbContext context,
         ILogger<PhotoQueryServiceV2> logger,
-        IStaticReferenceCache referenceCache)
+        IStaticReferenceCache referenceCache,
+        IQueryCountCache countCache)
     {
         _context = context;
         _logger = logger;
         _referenceCache = referenceCache;
+        _countCache = countCache;
     }
 
     public async Task<ApiResponse<List<PhotoResource>>> QueryPhotosAsync(
@@ -35,8 +38,8 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         // Build query with ALL filters (including Mars time) at the database level
         var query = BuildQuery(parameters);
 
-        // Get total count for pagination metadata
-        var totalCount = await query.CountAsync(cancellationToken);
+        // Get total count for pagination metadata (cached; see IQueryCountCache)
+        var totalCount = await _countCache.GetOrSetCountAsync(query, cancellationToken);
 
         // Apply sorting
         query = ApplySorting(query, parameters);

--- a/src/MarsVista.Api/Services/V2/QueryCountCache.cs
+++ b/src/MarsVista.Api/Services/V2/QueryCountCache.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Services.V2;
+
+/// <summary>
+/// Serves pagination total counts from the two-level cache instead of running
+/// COUNT(*) per request. A rover-filtered count scans ~500K index entries
+/// (~184 MB of buffer reads) on production, and gallery browsing repeats the
+/// same filter shapes constantly, so counts are cached for up to an hour.
+/// Photos only change via the daily 2 AM scraper, so a stale count is at most
+/// one sol's worth of photos behind.
+/// </summary>
+public interface IQueryCountCache
+{
+    /// <summary>
+    /// Returns the row count of <paramref name="query"/>, served from cache
+    /// when an identical query shape was counted within the TTL.
+    /// </summary>
+    Task<int> GetOrSetCountAsync(IQueryable<Photo> query, CancellationToken cancellationToken = default);
+}
+
+public class QueryCountCache : IQueryCountCache
+{
+    private readonly ICachingServiceV2 _cachingService;
+
+    public QueryCountCache(ICachingServiceV2 cachingService)
+    {
+        _cachingService = cachingService;
+    }
+
+    public async Task<int> GetOrSetCountAsync(IQueryable<Photo> query, CancellationToken cancellationToken = default)
+    {
+        // ToQueryString() renders the query's SQL with its parameter values, so the
+        // key automatically incorporates every filter BuildQuery applied - no
+        // hand-maintained parameter list to drift when a filter is added. The SQL
+        // text changes across EF/Npgsql upgrades, which merely rotates keys (cold
+        // misses for one TTL window).
+        var key = _cachingService.GenerateCacheKey("photocount", HashQuery(query.ToQueryString()));
+
+        var cached = await _cachingService.GetOrSetAsync(
+            key,
+            async () => new CachedCount(await query.CountAsync(cancellationToken)));
+
+        return cached?.Value ?? await query.CountAsync(cancellationToken);
+    }
+
+    private static string HashQuery(string sql)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sql));
+        return Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Wrapper because <see cref="ICachingServiceV2.GetOrSetAsync{T}"/> requires a
+    /// reference type.
+    /// </summary>
+    private sealed record CachedCount(int Value);
+}

--- a/src/MarsVista.Api/Services/V2/RoverQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/RoverQueryServiceV2.cs
@@ -12,15 +12,18 @@ public class RoverQueryServiceV2 : IRoverQueryServiceV2
     private readonly MarsVistaDbContext _context;
     private readonly ICachingServiceV2 _cachingService;
     private readonly ILogger<RoverQueryServiceV2> _logger;
+    private readonly IQueryCountCache _countCache;
 
     public RoverQueryServiceV2(
         MarsVistaDbContext context,
         ICachingServiceV2 cachingService,
-        ILogger<RoverQueryServiceV2> logger)
+        ILogger<RoverQueryServiceV2> logger,
+        IQueryCountCache countCache)
     {
         _context = context;
         _cachingService = cachingService;
         _logger = logger;
+        _countCache = countCache;
     }
 
     public async Task<List<RoverResource>> GetAllRoversAsync(CancellationToken cancellationToken = default)
@@ -134,8 +137,11 @@ public class RoverQueryServiceV2 : IRoverQueryServiceV2
         // Determine if this is an active rover for cache duration
         var isActiveRover = rover.Status?.ToLowerInvariant() == "active";
 
-        // Include photo count in cache key for auto-invalidation when new photos are added
-        var photoCount = await _context.Photos.CountAsync(p => p.RoverId == rover.Id, cancellationToken);
+        // Include photo count in cache key for auto-invalidation when new photos are added.
+        // The count itself is served from the count cache, so invalidation lags the daily
+        // scrape by at most the count TTL (1 h) instead of costing a COUNT(*) per request.
+        var photoCount = await _countCache.GetOrSetCountAsync(
+            _context.Photos.Where(p => p.RoverId == rover.Id), cancellationToken);
         var cacheKey = _cachingService.GenerateCacheKey("manifest", slug.ToLowerInvariant(), photoCount);
 
         var manifest = await _cachingService.GetOrSetAsync(

--- a/tests/MarsVista.Api.Tests/Integration/IntegrationTestBase.cs
+++ b/tests/MarsVista.Api.Tests/Integration/IntegrationTestBase.cs
@@ -135,6 +135,18 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         // Lazy init means it picks up the seeded rovers/cameras on first call.
         services.AddSingleton<IStaticReferenceCache, StaticReferenceCache>();
 
+        // Count cache is required by the photo query services (v1 and v2) and the
+        // manifest services. Registered with a null Redis multiplexer so tests run
+        // on the L1 (memory) level only - the same graceful-degradation path
+        // production takes when Redis is down.
+        services.AddMemoryCache();
+        services.AddSingleton<MarsVista.Api.Services.V2.ICachingServiceV2>(sp =>
+            new MarsVista.Api.Services.V2.CachingServiceV2(
+                sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(),
+                null,
+                sp.GetRequiredService<ILogger<MarsVista.Api.Services.V2.CachingServiceV2>>()));
+        services.AddScoped<MarsVista.Api.Services.V2.IQueryCountCache, MarsVista.Api.Services.V2.QueryCountCache>();
+
         ConfigureServices(services);
 
         return services.BuildServiceProvider();

--- a/tests/MarsVista.Api.Tests/Integration/V1/QueryCountCacheV1Tests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V1/QueryCountCacheV1Tests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MarsVista.Api.Services;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Tests.Integration.V1;
+
+/// <summary>
+/// Verifies the v1 photo query service serves pagination total counts from the
+/// count cache instead of running COUNT(*) per request - same contract as the
+/// v2 tests in QueryCountCacheTests.
+/// </summary>
+public class QueryCountCacheV1Tests : IntegrationTestBase
+{
+    private IPhotoQueryService _photoQueryService = null!;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IPhotoQueryService, PhotoQueryService>();
+    }
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        _photoQueryService = ServiceProvider.GetRequiredService<IPhotoQueryService>();
+
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "V1CC-1", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 100, EarthDate = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "V1CC-2", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 100, EarthDate = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2014, 1, 1, 6, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 2,
+                CreatedAt = now, UpdatedAt = now,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+    }
+
+    private static List<string> CountSqls(IReadOnlyList<string> executed) =>
+        executed.Where(s => s.Contains("count(*)", StringComparison.OrdinalIgnoreCase)).ToList();
+
+    [Fact]
+    public async Task SecondIdenticalQuery_ServesCountFromCache_WithoutCountSql()
+    {
+        SqlCapture.Clear();
+        var (firstPhotos, firstTotal) = await _photoQueryService.QueryPhotosAsync(
+            "curiosity", sol: 100, page: 1, perPage: 10);
+        CountSqls(SqlCapture.ExecutedSql).Should().NotBeEmpty(
+            "the first request has a cold cache and must run the real COUNT");
+        firstTotal.Should().Be(2);
+        firstPhotos.Should().HaveCount(2);
+
+        SqlCapture.Clear();
+        var (secondPhotos, secondTotal) = await _photoQueryService.QueryPhotosAsync(
+            "curiosity", sol: 100, page: 1, perPage: 10);
+        CountSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "an identical v1 filter set within the cache TTL must not run COUNT(*) again");
+        secondTotal.Should().Be(2, "the cached count must equal the real count");
+        secondPhotos.Should().HaveCount(2, "photo rows are still fetched live");
+    }
+
+    [Fact]
+    public async Task PaginationParameters_DoNotFragmentTheCountCache()
+    {
+        await _photoQueryService.QueryPhotosAsync("curiosity", sol: 100, page: 1, perPage: 1);
+
+        SqlCapture.Clear();
+        var (photos, total) = await _photoQueryService.QueryPhotosAsync(
+            "curiosity", sol: 100, page: 2, perPage: 1);
+
+        CountSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "page/per_page do not affect the total, so page 2 must reuse page 1's cached count");
+        total.Should().Be(2);
+        photos.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DifferentCameraFilter_UsesDistinctCacheEntry()
+    {
+        var (_, allTotal) = await _photoQueryService.QueryPhotosAsync("curiosity", sol: 100);
+
+        SqlCapture.Clear();
+        var (_, fhazTotal) = await _photoQueryService.QueryPhotosAsync("curiosity", sol: 100, camera: "FHAZ");
+
+        CountSqls(SqlCapture.ExecutedSql).Should().NotBeEmpty(
+            "a camera-filtered count is a different cache key, so its first request must run COUNT");
+        allTotal.Should().Be(2);
+        fhazTotal.Should().Be(1, "the FHAZ count must not be served from the unfiltered entry");
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/V2/ManifestCountCacheTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/ManifestCountCacheTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MarsVista.Api.Services;
+using MarsVista.Api.Services.V2;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Tests.Integration.V2;
+
+/// <summary>
+/// The manifest endpoints embed the rover's photo count in their cache key
+/// ("auto-invalidation via key mutation"), which means the COUNT(*) itself ran
+/// on every manifest request even when the manifest body was cached. These
+/// tests pin the fix: the count comes from the shared count cache, so a second
+/// manifest request within the TTL executes no SQL against photos at all.
+/// </summary>
+public class ManifestCountCacheTests : IntegrationTestBase
+{
+    private IRoverQueryServiceV2 _roverServiceV2 = null!;
+    private IRoverQueryService _roverServiceV1 = null!;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IRoverQueryServiceV2, RoverQueryServiceV2>();
+        services.AddScoped<IRoverQueryService, RoverQueryService>();
+    }
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        _roverServiceV2 = ServiceProvider.GetRequiredService<IRoverQueryServiceV2>();
+        _roverServiceV1 = ServiceProvider.GetRequiredService<IRoverQueryService>();
+
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "MCC-1", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 1, EarthDate = new DateTime(2013, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2013, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "MCC-2", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 2, EarthDate = new DateTime(2013, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2013, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 2,
+                CreatedAt = now, UpdatedAt = now,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+    }
+
+    // Match SQL against the photos TABLE. The rovers lookup that legitimately runs
+    // on every request selects a total_photos column, so a bare "photos" substring
+    // would false-positive on it.
+    private static List<string> PhotosSqls(IReadOnlyList<string> executed) =>
+        executed.Where(s => s.Contains("FROM photos", StringComparison.OrdinalIgnoreCase)).ToList();
+
+    [Fact]
+    public async Task V2Manifest_SecondRequest_ExecutesNoPhotosSql()
+    {
+        var first = await _roverServiceV2.GetRoverManifestAsync("curiosity", default);
+        first!.Attributes!.TotalPhotos.Should().Be(2);
+
+        SqlCapture.Clear();
+        var second = await _roverServiceV2.GetRoverManifestAsync("curiosity", default);
+
+        PhotosSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "the second manifest request must serve both the photo count and the manifest body from cache");
+        second!.Attributes!.TotalPhotos.Should().Be(2);
+        second.Attributes.Photos.Should().HaveCount(2, "one manifest entry per seeded sol");
+    }
+
+    [Fact]
+    public async Task V1Manifest_SecondRequest_ExecutesNoPhotosSql()
+    {
+        var first = await _roverServiceV1.GetManifestAsync("curiosity", default);
+        first!.TotalPhotos.Should().Be(2);
+
+        SqlCapture.Clear();
+        var second = await _roverServiceV1.GetManifestAsync("curiosity", default);
+
+        PhotosSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "the second v1 manifest request must serve both the photo count and the manifest body from cache");
+        second!.TotalPhotos.Should().Be(2);
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/V2/QueryCountCacheTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/QueryCountCacheTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MarsVista.Api.Models.V2;
+using MarsVista.Api.Services.V2;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Tests.Integration.V2;
+
+/// <summary>
+/// Verifies that pagination total counts are served from the two-level cache
+/// instead of running COUNT(*) on every request. In production each
+/// rover-filtered count scans ~500K index entries (~184 MB of buffer reads),
+/// so the second identical request must not touch the database for the count.
+///
+/// Uses SqlCapturingInterceptor to assert on the SQL the real service path
+/// emits (see PhotoQuerySqlGenerationTests for the pattern).
+/// </summary>
+public class QueryCountCacheTests : IntegrationTestBase
+{
+    private IPhotoQueryServiceV2 _photoQueryService = null!;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IPhotoQueryServiceV2, PhotoQueryServiceV2>();
+    }
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        _photoQueryService = ServiceProvider.GetRequiredService<IPhotoQueryServiceV2>();
+
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "CC-CUR-1", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 100, EarthDate = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "CC-CUR-2", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 101, EarthDate = new DateTime(2014, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2014, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "CC-PER-1", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 500, EarthDate = new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full",
+                RoverId = 2, CameraId = 3,
+                CreatedAt = now, UpdatedAt = now,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+    }
+
+    private static List<string> CountSqls(IReadOnlyList<string> executed) =>
+        executed.Where(s => s.Contains("count(*)", StringComparison.OrdinalIgnoreCase)).ToList();
+
+    [Fact]
+    public async Task SecondIdenticalQuery_ServesCountFromCache_WithoutCountSql()
+    {
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            Page = 1, PerPage = 10,
+        };
+
+        SqlCapture.Clear();
+        var first = await _photoQueryService.QueryPhotosAsync(parameters, default);
+        CountSqls(SqlCapture.ExecutedSql).Should().NotBeEmpty(
+            "the first request has a cold cache and must run the real COUNT");
+        first.Meta!.TotalCount.Should().Be(2);
+
+        SqlCapture.Clear();
+        var second = await _photoQueryService.QueryPhotosAsync(parameters, default);
+        CountSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "an identical filter set within the cache TTL must not run COUNT(*) again");
+        second.Meta!.TotalCount.Should().Be(2, "the cached count must equal the real count");
+        second.Data.Should().HaveCount(2, "only the count is cached - photo rows are still fetched live");
+    }
+
+    [Fact]
+    public async Task DifferentFilterValues_UseDistinctCacheEntries()
+    {
+        var curiosity = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            Page = 1, PerPage = 10,
+        };
+        var perseverance = new PhotoQueryParameters
+        {
+            Rovers = "perseverance",
+            RoverList = new List<string> { "perseverance" },
+            Page = 1, PerPage = 10,
+        };
+
+        var curResponse = await _photoQueryService.QueryPhotosAsync(curiosity, default);
+
+        SqlCapture.Clear();
+        var perResponse = await _photoQueryService.QueryPhotosAsync(perseverance, default);
+
+        CountSqls(SqlCapture.ExecutedSql).Should().NotBeEmpty(
+            "a different rover filter is a different cache key, so its first request must run COUNT");
+        curResponse.Meta!.TotalCount.Should().Be(2);
+        perResponse.Meta!.TotalCount.Should().Be(1, "the perseverance count must not be served from the curiosity entry");
+    }
+
+    [Fact]
+    public async Task PaginationParameters_DoNotFragmentTheCountCache()
+    {
+        var page1 = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            Page = 1, PerPage = 1,
+        };
+        var page2 = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            Page = 2, PerPage = 1,
+        };
+
+        await _photoQueryService.QueryPhotosAsync(page1, default);
+
+        SqlCapture.Clear();
+        var second = await _photoQueryService.QueryPhotosAsync(page2, default);
+
+        CountSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "page/per_page do not affect the total count, so page 2 must reuse page 1's cached count");
+        second.Meta!.TotalCount.Should().Be(2);
+        second.Data.Should().ContainSingle("per_page=1 still returns one live row");
+    }
+
+    [Fact]
+    public async Task UnfilteredQuery_IsCachedToo()
+    {
+        var parameters = new PhotoQueryParameters { Page = 1, PerPage = 10 };
+
+        await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        SqlCapture.Clear();
+        var second = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        CountSqls(SqlCapture.ExecutedSql).Should().BeEmpty(
+            "the unfiltered (all-photos) count is the most expensive shape and must be cached");
+        second.Meta!.TotalCount.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

Production measurement (July 7) found ~100 GB/day of Postgres buffer reads with flat traffic, dominated by pagination `COUNT(*)` queries: every rover-filtered gallery request recounts ~500K rows (~184 MB of buffer reads per request, verified via `EXPLAIN (ANALYZE, BUFFERS)`), with 52-75 s outliers when the cache is cold. The repeated scans keep the whole photos heap resident in the OS page cache, which is what drives the Railway RAM bill. The manifest endpoints additionally ran the same count on every request just to build their cache key.

This PR serves those counts from the existing two-level cache (L1 memory 15 min, L2 Redis 1 h):

- **QueryCountCache**: counts are keyed by a SHA-256 prefix of the filtered query's `ToQueryString()` output, so the key automatically incorporates every filter `BuildQuery` applies — adding a filter can never silently alias a stale entry. Pagination/sort parameters are applied after the count and do not fragment the cache.
- **v2 + v1 photo queries**: `CountAsync` per request → cached count.
- **v1 + v2 manifests**: the photo count embedded in the manifest cache key now comes from the count cache; a second manifest request within the TTL executes no SQL against the photos table at all. Key rotation after the daily scrape lags by at most 1 h; inactive rovers are unaffected.

Counts can lag up to 1 h behind the daily 2 AM scrape — a gallery total one sol behind is acceptable for this product.

## Testing

- New integration tests assert on SQL captured from the real service paths (SqlCapturingInterceptor): second identical request must execute zero COUNT statements; different filters use distinct entries; page changes reuse the cached count.
- Tests run with a null Redis multiplexer, covering the L1-only graceful-degradation path.
- Full suite: 455 tests green.

## Post-deploy verification (24 h gate)

- `pg_stat_user_indexes.idx_tup_read` growth on `ix_photos_rover_id_earth_date`: expect ~190 M/day → ~5 M/day.
- `redis-cli --scan --pattern 'marsvista:photocount*'` shows keys with ~1 h TTL.
- Warm-vs-cold timing on `/api/v2/photos?rovers=curiosity&page=2`.