### PR TITLE
Add usage_events retention with monthly rollup

### DIFF
--- a/src/MarsVista.Core/Data/MarsVistaDbContext.cs
+++ b/src/MarsVista.Core/Data/MarsVistaDbContext.cs
@@ -17,6 +17,7 @@ public class MarsVistaDbContext : DbContext
     public DbSet<ApiKey> ApiKeys { get; set; }
     public DbSet<RateLimit> RateLimits { get; set; }
     public DbSet<UsageEvent> UsageEvents { get; set; }
+    public DbSet<UsageEventMonthly> UsageEventsMonthly { get; set; }
     public DbSet<ScraperState> ScraperStates { get; set; }
     public DbSet<ScraperJobHistory> ScraperJobHistories { get; set; }
     public DbSet<ScraperJobRoverDetails> ScraperJobRoverDetails { get; set; }
@@ -218,6 +219,30 @@ public class MarsVistaDbContext : DbContext
 
             // Timestamp with default value
             entity.Property(e => e.CreatedAt)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        // UsageEventMonthly configuration (retention rollup of usage_events)
+        modelBuilder.Entity<UsageEventMonthly>(entity =>
+        {
+            entity.ToTable("usage_events_monthly");
+
+            entity.HasKey(e => e.Id);
+
+            // The retention job's ON CONFLICT target: one row per
+            // (month, user, endpoint, tier) that accumulates across runs.
+            entity.HasIndex(e => new { e.Month, e.UserEmail, e.Endpoint, e.Tier })
+                .IsUnique();
+
+            // String length constraints (match usage_events)
+            entity.Property(e => e.UserEmail).HasMaxLength(255).IsRequired();
+            entity.Property(e => e.Endpoint).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.Tier).HasMaxLength(20).IsRequired();
+
+            // Timestamps with default values
+            entity.Property(e => e.CreatedAt)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 

--- a/src/MarsVista.Core/Data/Migrations/20260707182036_AddUsageEventsMonthlyTable.Designer.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260707182036_AddUsageEventsMonthlyTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using MarsVista.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MarsVista.Core.Data.Migrations
 {
     [DbContext(typeof(MarsVistaDbContext))]
-    partial class MarsVistaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707182036_AddUsageEventsMonthlyTable")]
+    partial class AddUsageEventsMonthlyTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MarsVista.Core/Data/Migrations/20260707182036_AddUsageEventsMonthlyTable.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260707182036_AddUsageEventsMonthlyTable.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MarsVista.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsageEventsMonthlyTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "usage_events_monthly",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    month = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    user_email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    endpoint = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    tier = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    request_count = table.Column<long>(type: "bigint", nullable: false),
+                    total_response_time_ms = table.Column<long>(type: "bigint", nullable: false),
+                    total_photos_returned = table.Column<long>(type: "bigint", nullable: false),
+                    error_count = table.Column<long>(type: "bigint", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_usage_events_monthly", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_usage_events_monthly_month_user_email_endpoint_tier",
+                table: "usage_events_monthly",
+                columns: new[] { "month", "user_email", "endpoint", "tier" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "usage_events_monthly");
+        }
+    }
+}

--- a/src/MarsVista.Core/Entities/UsageEventMonthly.cs
+++ b/src/MarsVista.Core/Entities/UsageEventMonthly.cs
@@ -1,0 +1,64 @@
+namespace MarsVista.Core.Entities;
+
+/// <summary>
+/// Monthly rollup of usage_events, populated by the retention job when raw
+/// events older than the retention window are deleted. Lifetime statistics
+/// remain queryable as SUM over this table plus the live usage_events window.
+/// </summary>
+public class UsageEventMonthly
+{
+    /// <summary>
+    /// Unique identifier for the rollup row
+    /// </summary>
+    public long Id { get; set; }
+
+    /// <summary>
+    /// First instant of the calendar month (UTC) this row aggregates
+    /// </summary>
+    public DateTime Month { get; set; }
+
+    /// <summary>
+    /// User's email address (from API key authentication)
+    /// </summary>
+    public string UserEmail { get; set; } = string.Empty;
+
+    /// <summary>
+    /// API endpoint that was called
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// User's subscription tier at time of the requests
+    /// </summary>
+    public string Tier { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of requests aggregated into this row
+    /// </summary>
+    public long RequestCount { get; set; }
+
+    /// <summary>
+    /// Sum of response times in milliseconds (average = total / request_count)
+    /// </summary>
+    public long TotalResponseTimeMs { get; set; }
+
+    /// <summary>
+    /// Sum of photos returned across the aggregated requests
+    /// </summary>
+    public long TotalPhotosReturned { get; set; }
+
+    /// <summary>
+    /// Number of aggregated requests with status code >= 400
+    /// </summary>
+    public long ErrorCount { get; set; }
+
+    /// <summary>
+    /// When this rollup row was first created
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// When this rollup row last accumulated a new batch
+    /// </summary>
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/MarsVista.Core/Services/UsageEventRetentionService.cs
+++ b/src/MarsVista.Core/Services/UsageEventRetentionService.cs
@@ -1,0 +1,99 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Data;
+
+namespace MarsVista.Core.Services;
+
+/// <summary>
+/// Deletes usage_events older than a retention window, aggregating the deleted
+/// rows into the usage_events_monthly rollup in the same atomic statement so
+/// lifetime statistics survive the purge.
+/// </summary>
+public interface IUsageEventRetentionService
+{
+    /// <summary>
+    /// Purges events older than <paramref name="retentionDays"/> and rolls their
+    /// statistics into usage_events_monthly. Returns the number of events deleted.
+    /// </summary>
+    Task<int> PurgeAndRollUpAsync(int retentionDays = 90, CancellationToken cancellationToken = default);
+}
+
+public class UsageEventRetentionService : IUsageEventRetentionService
+{
+    // Single atomic statement: the DELETE ... RETURNING feeds the rollup INSERT,
+    // and the outer SELECT reports how many rows were purged. Data-modifying CTEs
+    // always run to completion even when the primary query does not reference
+    // them, so `rolled` executes whether or not any rows were deleted.
+    private const string PurgeAndRollUpSql = @"
+WITH deleted AS (
+    DELETE FROM usage_events
+    WHERE created_at < NOW() - make_interval(days => @retention_days)
+    RETURNING user_email, endpoint, tier, response_time_ms, photos_returned, status_code, created_at
+),
+rolled AS (
+    INSERT INTO usage_events_monthly
+        (month, user_email, endpoint, tier, request_count,
+         total_response_time_ms, total_photos_returned, error_count, created_at, updated_at)
+    SELECT
+        date_trunc('month', created_at),
+        user_email, endpoint, tier,
+        COUNT(*),
+        SUM(response_time_ms),
+        SUM(photos_returned),
+        COUNT(*) FILTER (WHERE status_code >= 400),
+        NOW(), NOW()
+    FROM deleted
+    GROUP BY date_trunc('month', created_at), user_email, endpoint, tier
+    ON CONFLICT (month, user_email, endpoint, tier) DO UPDATE SET
+        request_count = usage_events_monthly.request_count + EXCLUDED.request_count,
+        total_response_time_ms = usage_events_monthly.total_response_time_ms + EXCLUDED.total_response_time_ms,
+        total_photos_returned = usage_events_monthly.total_photos_returned + EXCLUDED.total_photos_returned,
+        error_count = usage_events_monthly.error_count + EXCLUDED.error_count,
+        updated_at = NOW()
+)
+SELECT COUNT(*) FROM deleted";
+
+    // The first purge deletes the entire backlog in one transaction; give it
+    // generous headroom over the default command timeout.
+    private const int CommandTimeoutSeconds = 300;
+
+    private readonly MarsVistaDbContext _context;
+
+    public UsageEventRetentionService(MarsVistaDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> PurgeAndRollUpAsync(int retentionDays = 90, CancellationToken cancellationToken = default)
+    {
+        var connection = _context.Database.GetDbConnection();
+
+        var openedHere = connection.State != ConnectionState.Open;
+        if (openedHere)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = PurgeAndRollUpSql;
+            command.CommandTimeout = CommandTimeoutSeconds;
+
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "retention_days";
+            parameter.Value = retentionDays;
+            command.Parameters.Add(parameter);
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(result);
+        }
+        finally
+        {
+            if (openedHere)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+}

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -72,6 +72,11 @@ try
     builder.Services.AddScoped<ISolCompletenessRepository, SolCompletenessRepository>();
     builder.Services.AddScoped<IIncrementalScraperService, IncrementalScraperService>();
 
+    // Daily maintenance: prune usage_events past the retention window into the
+    // monthly rollup. Runs after the scrape as a best-effort step.
+    builder.Services.AddScoped<MarsVista.Core.Services.IUsageEventRetentionService,
+        MarsVista.Core.Services.UsageEventRetentionService>();
+
     // Configure scraper schedule options
     builder.Services.Configure<ScraperScheduleOptions>(
         builder.Configuration.GetSection(ScraperScheduleOptions.SectionName));
@@ -131,6 +136,31 @@ try
             string.Join(", ", succeeded),
             string.Join(", ", failed));
         Environment.ExitCode = 1; // Non-zero exit code for Railway monitoring
+    }
+
+    // Best-effort daily maintenance. Wrapped so a retention failure is logged
+    // but never changes the scrape's exit code - the scrape is the job that
+    // Railway monitors, not the cleanup.
+    try
+    {
+        var retentionDays = 90;
+        var retentionEnv = Environment.GetEnvironmentVariable("USAGE_EVENTS_RETENTION_DAYS");
+        if (!string.IsNullOrEmpty(retentionEnv) && int.TryParse(retentionEnv, out var configuredDays))
+        {
+            retentionDays = configuredDays;
+        }
+
+        using var retentionScope = host.Services.CreateScope();
+        var retentionService = retentionScope.ServiceProvider
+            .GetRequiredService<MarsVista.Core.Services.IUsageEventRetentionService>();
+        var purged = await retentionService.PurgeAndRollUpAsync(retentionDays);
+        Log.Information(
+            "Usage-event retention complete: purged {Purged} events older than {RetentionDays} days into monthly rollup",
+            purged, retentionDays);
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Usage-event retention failed (scrape result unaffected)");
     }
 
     Log.Information("Mars Vista Scraper finished");

--- a/tests/MarsVista.Api.Tests/Integration/UsageEventMonthlyMigrationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/UsageEventMonthlyMigrationTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// Proves the usage_events_monthly rollup table was created by the migration and
+/// enforces the (month, user_email, endpoint, tier) unique key the retention
+/// job's ON CONFLICT clause depends on. IntegrationTestBase runs MigrateAsync in
+/// InitializeAsync, so reaching these assertions at all means the migration
+/// applied cleanly.
+/// </summary>
+public class UsageEventMonthlyMigrationTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task RollupTable_RoundTripsARow()
+    {
+        var month = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DbContext.UsageEventsMonthly.Add(new UsageEventMonthly
+        {
+            Month = month,
+            UserEmail = "someone@example.com",
+            Endpoint = "/api/v2/photos",
+            Tier = "free",
+            RequestCount = 42,
+            TotalResponseTimeMs = 8400,
+            TotalPhotosReturned = 1008,
+            ErrorCount = 3,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await DbContext.SaveChangesAsync();
+
+        var row = await DbContext.UsageEventsMonthly.AsNoTracking()
+            .SingleAsync(r => r.UserEmail == "someone@example.com");
+
+        row.RequestCount.Should().Be(42);
+        row.TotalResponseTimeMs.Should().Be(8400);
+        row.ErrorCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task RollupTable_RejectsDuplicateMonthUserEndpointTier()
+    {
+        var month = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+        UsageEventMonthly MakeRow() => new()
+        {
+            Month = month,
+            UserEmail = "dup@example.com",
+            Endpoint = "/api/v2/rovers",
+            Tier = "pro",
+            RequestCount = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        DbContext.UsageEventsMonthly.Add(MakeRow());
+        await DbContext.SaveChangesAsync();
+
+        // A second row with the same (month, user, endpoint, tier) must violate
+        // the unique index - this is what makes the retention job's upsert safe.
+        DbContext.UsageEventsMonthly.Add(MakeRow());
+        var act = async () => await DbContext.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/UsageEventRetentionServiceTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/UsageEventRetentionServiceTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Entities;
+using MarsVista.Core.Services;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// Verifies the retention job deletes usage_events older than the retention
+/// window while conserving their statistics in the monthly rollup. The
+/// aggregate-then-delete runs as one atomic statement, so a crash cannot lose
+/// events without also having rolled them up.
+/// </summary>
+public class UsageEventRetentionServiceTests : IntegrationTestBase
+{
+    private UsageEventRetentionService _service = null!;
+
+    protected override Task SeedAdditionalDataAsync()
+    {
+        _service = new UsageEventRetentionService(DbContext);
+        return Task.CompletedTask;
+    }
+
+    private void AddEvent(DateTime createdAt, string email, string endpoint, string tier,
+        int responseMs, int photos, int status)
+    {
+        DbContext.UsageEvents.Add(new UsageEvent
+        {
+            UserEmail = email,
+            Endpoint = endpoint,
+            Tier = tier,
+            ResponseTimeMs = responseMs,
+            PhotosReturned = photos,
+            StatusCode = status,
+            CreatedAt = DateTime.SpecifyKind(createdAt, DateTimeKind.Utc),
+        });
+    }
+
+    [Fact]
+    public async Task DeletesOldEvents_KeepsRecent_AndRollsUpStatistics()
+    {
+        var now = DateTime.UtcNow;
+        // Two old events in the same month/user/endpoint/tier -> one rollup row, count 2.
+        AddEvent(now.AddDays(-120), "old@x.dev", "/api/v2/photos", "free", 100, 10, 200);
+        AddEvent(now.AddDays(-118), "old@x.dev", "/api/v2/photos", "free", 300, 20, 500);
+        // Recent event must be left untouched.
+        AddEvent(now.AddDays(-5), "new@x.dev", "/api/v2/photos", "free", 50, 5, 200);
+        await DbContext.SaveChangesAsync();
+
+        var deleted = await _service.PurgeAndRollUpAsync(retentionDays: 90);
+
+        deleted.Should().Be(2, "both events older than 90 days are purged");
+
+        var remaining = await DbContext.UsageEvents.AsNoTracking().ToListAsync();
+        remaining.Should().ContainSingle(e => e.UserEmail == "new@x.dev");
+        remaining.Should().NotContain(e => e.UserEmail == "old@x.dev");
+
+        var rollup = await DbContext.UsageEventsMonthly.AsNoTracking()
+            .SingleAsync(r => r.UserEmail == "old@x.dev");
+        rollup.RequestCount.Should().Be(2);
+        rollup.TotalResponseTimeMs.Should().Be(400, "100 + 300");
+        rollup.TotalPhotosReturned.Should().Be(30, "10 + 20");
+        rollup.ErrorCount.Should().Be(1, "only the status 500 event counts as an error");
+        rollup.Month.Should().Be(new DateTime(now.AddDays(-120).Year, now.AddDays(-120).Month, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task IsIdempotent_SecondRunPurgesNothingAndDoesNotDoubleCount()
+    {
+        var now = DateTime.UtcNow;
+        AddEvent(now.AddDays(-200), "a@x.dev", "/api/v2/rovers", "pro", 40, 0, 200);
+        await DbContext.SaveChangesAsync();
+
+        var firstDeleted = await _service.PurgeAndRollUpAsync(retentionDays: 90);
+        var secondDeleted = await _service.PurgeAndRollUpAsync(retentionDays: 90);
+
+        firstDeleted.Should().Be(1);
+        secondDeleted.Should().Be(0, "nothing older than the window remains after the first run");
+
+        var rollup = await DbContext.UsageEventsMonthly.AsNoTracking()
+            .SingleAsync(r => r.UserEmail == "a@x.dev");
+        rollup.RequestCount.Should().Be(1, "the second empty run must not re-accumulate");
+    }
+
+    [Fact]
+    public async Task AccumulatesIntoExistingRollupRow_ViaOnConflict()
+    {
+        var now = DateTime.UtcNow;
+        var oldMonth = now.AddDays(-120);
+
+        // Pre-existing rollup row for the same (month, user, endpoint, tier).
+        DbContext.UsageEventsMonthly.Add(new UsageEventMonthly
+        {
+            Month = new DateTime(oldMonth.Year, oldMonth.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+            UserEmail = "acc@x.dev",
+            Endpoint = "/api/v2/photos",
+            Tier = "free",
+            RequestCount = 5,
+            TotalResponseTimeMs = 500,
+            TotalPhotosReturned = 50,
+            ErrorCount = 1,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        AddEvent(oldMonth, "acc@x.dev", "/api/v2/photos", "free", 200, 20, 404);
+        await DbContext.SaveChangesAsync();
+
+        await _service.PurgeAndRollUpAsync(retentionDays: 90);
+
+        var rollup = await DbContext.UsageEventsMonthly.AsNoTracking()
+            .SingleAsync(r => r.UserEmail == "acc@x.dev");
+        rollup.RequestCount.Should().Be(6, "5 existing + 1 purged");
+        rollup.TotalResponseTimeMs.Should().Be(700, "500 + 200");
+        rollup.ErrorCount.Should().Be(2, "1 existing + 1 new 404");
+    }
+
+    [Fact]
+    public async Task ConservesTotalRequestCount_AcrossPurge()
+    {
+        var now = DateTime.UtcNow;
+        for (var i = 0; i < 7; i++)
+            AddEvent(now.AddDays(-100 - i), "c@x.dev", $"/api/v2/e{i % 3}", "free", 10, 1, 200);
+        AddEvent(now.AddDays(-1), "c@x.dev", "/api/v2/live", "free", 10, 1, 200);
+        await DbContext.SaveChangesAsync();
+
+        var preTotal = await DbContext.UsageEvents.AsNoTracking().CountAsync();
+
+        await _service.PurgeAndRollUpAsync(retentionDays: 90);
+
+        var remaining = await DbContext.UsageEvents.AsNoTracking().CountAsync();
+        var rolledUp = await DbContext.UsageEventsMonthly.AsNoTracking().SumAsync(r => r.RequestCount);
+        (remaining + rolledUp).Should().Be(preTotal, "no event may be lost or double-counted");
+    }
+}


### PR DESCRIPTION
## Summary

`usage_events` has no retention and grows unbounded — 274 MB / 770K rows as of July, +30 MB/month — and the ops admin dashboard full-scans it ~200×/day, which contributes to the Postgres working-set pressure this story targets.

This PR adds a daily retention step to the scraper cron that deletes events older than 90 days, **aggregating them into a new `usage_events_monthly` rollup table first** so lifetime statistics remain queryable (the user's requirement — see below).

- **`usage_events_monthly`** (new table, EF migration): monthly aggregate keyed by unique `(month, user_email, endpoint, tier)`. Counters are `bigint` to survive lifetime accumulation.
- **`UsageEventRetentionService`** (in Core so the scraper calls it and Api.Tests can integration-test it): one atomic CTE — `DELETE ... RETURNING` feeds `INSERT ... ON CONFLICT DO UPDATE`, with the outer `SELECT COUNT(*)` reporting rows purged. Because it's a single statement, a crash cannot drop events without also having rolled them up; reruns are idempotent.
- **Scraper hook**: runs after the scrape as a best-effort step in its own try/catch — a retention failure is logged but never changes the scrape's exit code (Railway monitors the scrape, not the cleanup). Window configurable via `USAGE_EVENTS_RETENTION_DAYS`; 300 s command timeout covers the one-time bulk purge of the backlog.

### Querying lifetime stats after retention

```sql
-- lifetime request count per user = rolled-up months + live window
SELECT user_email, SUM(cnt) FROM (
  SELECT user_email, request_count AS cnt FROM usage_events_monthly
  UNION ALL
  SELECT user_email, 1 FROM usage_events
) t GROUP BY user_email ORDER BY 2 DESC;
```

## Testing

- Integration tests (real Postgres): deletes old / keeps recent / rolls up sums correctly; idempotent second run; ON CONFLICT accumulation into an existing rollup row; conservation invariant (`remaining + SUM(request_count) == pre_total`).
- Migration round-trip + unique-constraint enforcement.
- Full suite: 452 tests green.

## Post-deploy verification (first 2 AM cron)

- Snapshot `SELECT COUNT(*), SUM(response_time_ms), SUM(photos_returned) FROM usage_events;` before.
- After: conservation check across both tables; `SELECT MIN(created_at) FROM usage_events;` ≈ now()−90d.
- **One-time ops step**: `VACUUM FULL usage_events;` to reclaim the leading heap pages (plain autovacuum only truncates trailing pages, so the dashboard's scans would otherwise keep reading the old ~274 MB).
- Bump the Core submodule in mars-vista-ops after merge (entity addition).