### PR TITLE
Panorama pre-compute: detection to Core, table, builder, backfill

### DIFF
--- a/src/MarsVista.Api/Program.cs
+++ b/src/MarsVista.Api/Program.cs
@@ -197,6 +197,7 @@ builder.Services.AddHostedService<MarsVista.Api.Services.V2.CacheWarmingBackgrou
 builder.Services.AddHostedService<MarsVista.Api.Services.V2.CacheStatsLoggingService>();
 
 // v2 Phase 2 advanced features services
+builder.Services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IPanoramaService, MarsVista.Api.Services.V2.PanoramaService>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.ILocationService, MarsVista.Api.Services.V2.LocationService>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IJourneyService, MarsVista.Api.Services.V2.JourneyService>();

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using MarsVista.Core.Data;
 using MarsVista.Core.Entities;
+using MarsVista.Core.Services;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Core.Helpers;
 
@@ -15,25 +16,7 @@ public class PanoramaService : IPanoramaService
     private readonly MarsVistaDbContext _context;
     private readonly ILogger<PanoramaService> _logger;
     private readonly IPhotoQueryServiceV2 _photoService;
-
-    // Panorama detection parameters
-    private const float MinAzimuthRangeDegrees = 30.0f; // At least 30 degrees coverage
-    private const int MinPhotosForPanorama = 3; // At least 3 photos
-    private const int MinUniquePositions = 3; // At least 3 unique azimuth positions (stitchable)
-    private const float MaxTimeDeltaSeconds = 300.0f; // Max 5 minutes between photos
-
-    // Multi-row mosaic detection parameters
-    private const float ElevationTierGapDegrees = 5.0f; // Min gap between sorted elevations to start a new tier
-    private const float MinGridCompleteness = 0.40f; // Multi-row mosaic must fill 40% of grid cells
-
-    // Only cameras designed for panoramic imaging — excludes spectrometers (ChemCam, SuperCam RMI),
-    // hazard cameras (fixed FOV), arm cameras (MAHLI, SHERLOC), and descent/EDL cameras
-    private static readonly HashSet<string> PanoramicCameras = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "MAST", "NAVCAM",                               // Curiosity
-        "MCZ_LEFT", "MCZ_RIGHT", "NAVCAM_LEFT", "NAVCAM_RIGHT", // Perseverance
-        "PANCAM"                                         // Opportunity, Spirit
-    };
+    private readonly PanoramaDetector _detector;
 
     // Performance optimization: Limit sol range to prevent loading all photos into memory
     // TODO: Long-term solution should pre-compute panoramas in a dedicated table (see .claude/decisions/PANORAMA_OPTIMIZATION.md)
@@ -42,11 +25,13 @@ public class PanoramaService : IPanoramaService
     public PanoramaService(
         MarsVistaDbContext context,
         ILogger<PanoramaService> logger,
-        IPhotoQueryServiceV2 photoService)
+        IPhotoQueryServiceV2 photoService,
+        PanoramaDetector detector)
     {
         _context = context;
         _logger = logger;
         _photoService = photoService;
+        _detector = detector;
     }
 
     public async Task<ApiResponse<List<PanoramaResource>>> GetPanoramasAsync(
@@ -73,7 +58,7 @@ public class PanoramaService : IPanoramaService
                        p.MastAz.HasValue &&
                        p.MastEl.HasValue &&
                        p.SpacecraftClock.HasValue &&
-                       PanoramicCameras.Contains(p.Camera.Name));
+                       PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name));
 
         // Apply filters
         if (!string.IsNullOrWhiteSpace(rovers))
@@ -150,7 +135,7 @@ public class PanoramaService : IPanoramaService
 
             // Detect panoramas for this sol - index resets per sol for stable IDs
             var panoramaIndex = 0;
-            var solPanoramas = DetectPanoramasOptimized(solPhotos, minPhotos ?? MinPhotosForPanorama, ref panoramaIndex);
+            var solPanoramas = _detector.DetectPanoramasOptimized(solPhotos, minPhotos ?? PanoramaDetector.MinPhotosForPanorama, ref panoramaIndex);
 
             if (sols.Count <= 5 || solPanoramas.Count > 0)
             {
@@ -177,7 +162,7 @@ public class PanoramaService : IPanoramaService
                 var azimuths = p.Photos.Select(ph => ph.MastAz ?? 0);
                 var coverage = azimuths.Max() - azimuths.Min();
                 var positions = p.Photos.Select(ph => Math.Round(ph.MastAz ?? 0)).Distinct().Count();
-                return GetQualityTier(coverage, positions).Equals(quality, StringComparison.OrdinalIgnoreCase);
+                return PanoramaDetector.GetQualityTier(coverage, positions).Equals(quality, StringComparison.OrdinalIgnoreCase);
             });
         }
 
@@ -421,7 +406,7 @@ public class PanoramaService : IPanoramaService
                        p.MastAz.HasValue &&
                        p.MastEl.HasValue &&
                        p.SpacecraftClock.HasValue &&
-                       PanoramicCameras.Contains(p.Camera.Name));
+                       PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name));
 
         var photos = await query
             .Include(p => p.Rover)
@@ -433,351 +418,12 @@ public class PanoramaService : IPanoramaService
             .ThenBy(p => p.MastEl) // Must match GetPanoramasAsync ordering for consistent IDs
             .ToListAsync(cancellationToken);
 
-        var panoramas = DetectPanoramas(photos, MinPhotosForPanorama);
+        var panoramas = _detector.DetectPanoramas(photos, PanoramaDetector.MinPhotosForPanorama);
 
         if (sequenceIndex < 0 || sequenceIndex >= panoramas.Count)
             return null;
 
         return panoramas[sequenceIndex];
-    }
-
-    /// <summary>
-    /// Optimized panorama detection that processes sol batches.
-    /// Groups photos by location/camera, splits on time gaps, then classifies
-    /// as single-row or multi-row based on elevation tier clustering.
-    /// </summary>
-    private List<PanoramaSequence> DetectPanoramasOptimized(List<Photo> photos, int minPhotos, ref int panoramaIndex)
-    {
-        var panoramas = new List<PanoramaSequence>();
-
-        // Group by rover, sol, site, drive, and camera
-        var allGroups = photos
-            .GroupBy(p => new
-            {
-                p.RoverId,
-                p.Sol,
-                Site = p.Site ?? 0,
-                Drive = p.Drive ?? 0,
-                p.CameraId
-            })
-            .ToList();
-
-        _logger.LogDebug("DetectPanoramasOptimized: {PhotoCount} photos, {GroupCount} total groups, minPhotos={MinPhotos}",
-            photos.Count, allGroups.Count, minPhotos);
-
-        var groups = allGroups
-            .Where(g => g.Count() >= minPhotos)
-            .OrderBy(g => g.Key.RoverId)
-            .ThenBy(g => g.Key.Sol)
-            .ThenBy(g => g.Key.Site)
-            .ThenBy(g => g.Key.Drive)
-            .ThenBy(g => g.Key.CameraId)
-            .ToList();
-
-        _logger.LogDebug("DetectPanoramasOptimized: {QualifiedGroupCount} groups with >= {MinPhotos} photos",
-            groups.Count, minPhotos);
-
-        foreach (var group in groups)
-        {
-            var groupPhotos = group.OrderBy(p => p.SpacecraftClock).ThenBy(p => p.MastEl).ToList();
-
-            _logger.LogDebug("Processing group: CameraId={CameraId}, Site={Site}, Drive={Drive}, {PhotoCount} photos",
-                group.Key.CameraId, group.Key.Site, group.Key.Drive, groupPhotos.Count);
-
-            // Step 1: Split into time-contiguous blocks (no elevation check)
-            var blocks = BuildTimeContiguousBlocks(groupPhotos);
-
-            // Step 2: For each block, cluster elevations and classify
-            foreach (var block in blocks)
-            {
-                if (block.Count < minPhotos)
-                    continue;
-
-                var tiers = ClusterElevationTiers(block);
-
-                if (tiers.Count <= 1)
-                {
-                    // Single-row: validate with existing criteria
-                    if (IsValidPanorama(block))
-                    {
-                        var uniqueAz = block
-                            .Select(p => Math.Round(p.MastAz ?? 0))
-                            .Distinct()
-                            .Count();
-
-                        panoramas.Add(new PanoramaSequence
-                        {
-                            Photos = new List<Photo>(block),
-                            Index = panoramaIndex++,
-                            IsMultiRow = false,
-                            ElevationTierCount = 1,
-                            AzimuthColumnCount = uniqueAz
-                        });
-                    }
-                }
-                else
-                {
-                    // Multi-row candidate: validate with mosaic criteria
-                    if (IsValidMosaic(block, tiers, out var mosaicMetrics))
-                    {
-                        var elevations = block.Select(p => p.MastEl ?? 0).ToList();
-
-                        panoramas.Add(new PanoramaSequence
-                        {
-                            Photos = new List<Photo>(block),
-                            Index = panoramaIndex++,
-                            IsMultiRow = true,
-                            ElevationTierCount = tiers.Count,
-                            AzimuthColumnCount = mosaicMetrics!.MaxColumnsPerTier,
-                            MinElevation = elevations.Min(),
-                            MaxElevation = elevations.Max()
-                        });
-                    }
-                    else
-                    {
-                        // Fallback: try each tier as a single-row panorama.
-                        // A block with multiple elevation tiers that fails mosaic validation
-                        // may still contain valid single-row panoramas within individual tiers.
-                        foreach (var tier in tiers)
-                        {
-                            var tierPhotos = block
-                                .Where(p => GetElevationTier(p.MastEl ?? 0, tiers) == tier)
-                                .OrderBy(p => p.SpacecraftClock)
-                                .ThenBy(p => p.MastEl)
-                                .ToList();
-
-                            if (tierPhotos.Count >= minPhotos && IsValidPanorama(tierPhotos))
-                            {
-                                var uniqueAz = tierPhotos
-                                    .Select(p => Math.Round(p.MastAz ?? 0))
-                                    .Distinct()
-                                    .Count();
-
-                                panoramas.Add(new PanoramaSequence
-                                {
-                                    Photos = new List<Photo>(tierPhotos),
-                                    Index = panoramaIndex++,
-                                    IsMultiRow = false,
-                                    ElevationTierCount = 1,
-                                    AzimuthColumnCount = uniqueAz
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return panoramas;
-    }
-
-    /// <summary>
-    /// Split photos into time-contiguous blocks using only the time gap threshold.
-    /// No elevation check — multi-row mosaics sweep across elevation tiers continuously.
-    /// </summary>
-    private List<List<Photo>> BuildTimeContiguousBlocks(List<Photo> orderedPhotos)
-    {
-        var blocks = new List<List<Photo>>();
-        var current = new List<Photo>();
-
-        for (int i = 0; i < orderedPhotos.Count; i++)
-        {
-            if (current.Count == 0)
-            {
-                current.Add(orderedPhotos[i]);
-            }
-            else
-            {
-                var timeDelta = (orderedPhotos[i].SpacecraftClock ?? 0) - (current[^1].SpacecraftClock ?? 0);
-                if (timeDelta <= MaxTimeDeltaSeconds && timeDelta >= 0)
-                {
-                    current.Add(orderedPhotos[i]);
-                }
-                else
-                {
-                    blocks.Add(current);
-                    current = new List<Photo> { orderedPhotos[i] };
-                }
-            }
-        }
-
-        if (current.Count > 0)
-            blocks.Add(current);
-
-        return blocks;
-    }
-
-    /// <summary>
-    /// Cluster unique elevations into tiers using adaptive gap-based grouping.
-    /// Sorts unique rounded elevations, splits when consecutive gap >= ElevationTierGapDegrees.
-    /// Returns the center value of each tier.
-    /// </summary>
-    private static List<float> ClusterElevationTiers(List<Photo> photos)
-    {
-        var uniqueElevations = photos
-            .Select(p => MathF.Round(p.MastEl ?? 0))
-            .Distinct()
-            .OrderBy(e => e)
-            .ToList();
-
-        if (uniqueElevations.Count == 0)
-            return new List<float>();
-
-        var tiers = new List<float>();
-        var currentTier = new List<float> { uniqueElevations[0] };
-
-        for (int i = 1; i < uniqueElevations.Count; i++)
-        {
-            if (uniqueElevations[i] - uniqueElevations[i - 1] >= ElevationTierGapDegrees)
-            {
-                // Gap found — finalize current tier, start new one
-                tiers.Add(currentTier.Average());
-                currentTier = new List<float> { uniqueElevations[i] };
-            }
-            else
-            {
-                currentTier.Add(uniqueElevations[i]);
-            }
-        }
-
-        tiers.Add(currentTier.Average());
-        return tiers;
-    }
-
-    /// <summary>
-    /// Map a photo's elevation to its nearest tier center value.
-    /// </summary>
-    private static float GetElevationTier(float elevation, List<float> tiers)
-    {
-        return tiers.OrderBy(t => Math.Abs(t - elevation)).First();
-    }
-
-    private record MosaicMetrics(int MaxColumnsPerTier, int FilledCells, float Completeness);
-
-    /// <summary>
-    /// Validate a multi-row mosaic: azimuth range >= 30°, unique positions >= 3,
-    /// and grid completeness >= 40%. Returns computed grid metrics on success.
-    /// </summary>
-    private bool IsValidMosaic(List<Photo> photos, List<float> tiers, out MosaicMetrics? metrics)
-    {
-        metrics = null;
-
-        if (photos.Count < MinPhotosForPanorama)
-            return false;
-
-        var azimuths = photos.Select(p => p.MastAz ?? 0).ToList();
-        var azimuthRange = azimuths.Max() - azimuths.Min();
-
-        if (azimuthRange < MinAzimuthRangeDegrees)
-        {
-            _logger.LogDebug("IsValidMosaic: FAILED - azimuth range {Range}° < {Min}°", azimuthRange, MinAzimuthRangeDegrees);
-            return false;
-        }
-
-        var uniquePositions = photos
-            .Select(p => Math.Round(p.MastAz ?? 0))
-            .Distinct()
-            .Count();
-
-        if (uniquePositions < MinUniquePositions)
-        {
-            _logger.LogDebug("IsValidMosaic: FAILED - {UniquePos} unique positions < {Min}", uniquePositions, MinUniquePositions);
-            return false;
-        }
-
-        // Compute per-tier column counts in one pass
-        var tierColumnCounts = tiers.Select(tier =>
-        {
-            var tierPhotos = photos.Where(p => GetElevationTier(p.MastEl ?? 0, tiers) == tier);
-            return tierPhotos.Select(p => Math.Round(p.MastAz ?? 0)).Distinct().Count();
-        }).ToList();
-
-        var maxColumnsPerTier = tierColumnCounts.Max();
-
-        if (maxColumnsPerTier < MinUniquePositions)
-        {
-            _logger.LogDebug("IsValidMosaic: FAILED - max {Cols} columns per tier < {Min} required for stitching",
-                maxColumnsPerTier, MinUniquePositions);
-            return false;
-        }
-
-        // At least 2 tiers must have meaningful column counts for a real multi-row mosaic.
-        // One dense tier + sparse single-shot tiers is not a mosaic — it's a sweep with
-        // unrelated observations at different elevations (e.g., bracketed bursts).
-        var tiersWithEnoughColumns = tierColumnCounts.Count(c => c >= MinUniquePositions);
-        if (tiersWithEnoughColumns < 2)
-        {
-            _logger.LogDebug("IsValidMosaic: FAILED - only {Count} tier(s) have >= {Min} columns (need at least 2)",
-                tiersWithEnoughColumns, MinUniquePositions);
-            return false;
-        }
-
-        // Grid completeness: how many (tier, azimuth) cells are filled vs total possible
-        var totalCells = tiers.Count * maxColumnsPerTier;
-        var filledCells = tierColumnCounts.Sum();
-        var completeness = (float)filledCells / totalCells;
-
-        if (completeness < MinGridCompleteness)
-        {
-            _logger.LogDebug("IsValidMosaic: FAILED - grid completeness {Completeness:P0} < {Min:P0}",
-                completeness, MinGridCompleteness);
-            return false;
-        }
-
-        _logger.LogDebug("IsValidMosaic: PASSED - {Count} photos, {Tiers} tiers, {Range}° azimuth, {Completeness:P0} grid fill",
-            photos.Count, tiers.Count, azimuthRange, completeness);
-        metrics = new MosaicMetrics(maxColumnsPerTier, filledCells, completeness);
-        return true;
-    }
-
-    /// <summary>
-    /// Detect panorama sequences from a list of photos (legacy method for single sol)
-    /// </summary>
-    private List<PanoramaSequence> DetectPanoramas(List<Photo> photos, int minPhotos)
-    {
-        var panoramaIndex = 0;
-        return DetectPanoramasOptimized(photos, minPhotos, ref panoramaIndex);
-    }
-
-    /// <summary>
-    /// Check if a sequence qualifies as a panorama
-    /// </summary>
-    private bool IsValidPanorama(List<Photo> photos)
-    {
-        if (photos.Count < MinPhotosForPanorama)
-        {
-            _logger.LogDebug("IsValidPanorama: FAILED - {Count} photos < {Min} required",
-                photos.Count, MinPhotosForPanorama);
-            return false;
-        }
-
-        // Check azimuth range
-        var azimuths = photos.Select(p => p.MastAz ?? 0).ToList();
-        var azimuthRange = azimuths.Max() - azimuths.Min();
-
-        if (azimuthRange < MinAzimuthRangeDegrees)
-        {
-            _logger.LogDebug("IsValidPanorama: FAILED - azimuth range {Range}° < {Min}° required",
-                azimuthRange, MinAzimuthRangeDegrees);
-            return false;
-        }
-
-        // Count unique positions (round to nearest degree to handle float precision)
-        var uniquePositions = photos
-            .Select(p => Math.Round(p.MastAz ?? 0))
-            .Distinct()
-            .Count();
-
-        if (uniquePositions < MinUniquePositions)
-        {
-            _logger.LogDebug("IsValidPanorama: FAILED - {UniquePos} unique positions < {Min} required",
-                uniquePositions, MinUniquePositions);
-            return false;
-        }
-
-        _logger.LogDebug("IsValidPanorama: PASSED - {Count} photos, {Range}° coverage, {UniquePos} unique positions",
-            photos.Count, azimuthRange, uniquePositions);
-        return true;
     }
 
     /// <summary>
@@ -821,7 +467,7 @@ public class PanoramaService : IPanoramaService
         }
 
         // Calculate quality tier
-        var quality = GetQualityTier(coverageDegrees, uniquePositions);
+        var quality = PanoramaDetector.GetQualityTier(coverageDegrees, uniquePositions);
 
         // Get Mars time range (normalize so start <= end for reverse-sweep panoramas)
         string? marsTimeStart = null;
@@ -931,31 +577,6 @@ public class PanoramaService : IPanoramaService
     {
         var first = sequence.Photos.First();
         return $"pano_{first.Rover.Name.ToLowerInvariant()}_{first.Sol}_{sequence.Index}";
-    }
-
-    /// <summary>
-    /// Determine quality tier based on coverage and unique positions
-    /// </summary>
-    private static string GetQualityTier(float coverageDegrees, int uniquePositions)
-    {
-        if (coverageDegrees >= 300 && uniquePositions >= 10) return "full";
-        if (coverageDegrees >= 200 && uniquePositions >= 7) return "wide";
-        if (coverageDegrees >= 120 && uniquePositions >= 5) return "half";
-        return "partial";
-    }
-
-    /// <summary>
-    /// Internal class to represent a detected panorama sequence
-    /// </summary>
-    private class PanoramaSequence
-    {
-        public List<Photo> Photos { get; set; } = new();
-        public int Index { get; set; }
-        public bool IsMultiRow { get; set; }
-        public int ElevationTierCount { get; set; } = 1;
-        public int AzimuthColumnCount { get; set; }
-        public float MinElevation { get; set; }
-        public float MaxElevation { get; set; }
     }
 
     /// <summary>

--- a/src/MarsVista.Core/Data/MarsVistaDbContext.cs
+++ b/src/MarsVista.Core/Data/MarsVistaDbContext.cs
@@ -25,6 +25,7 @@ public class MarsVistaDbContext : DbContext
     public DbSet<SolCompleteness> SolCompleteness { get; set; }
     public DbSet<StitchedPanorama> StitchedPanoramas { get; set; }
     public DbSet<PanoramaRating> PanoramaRatings { get; set; }
+    public DbSet<Panorama> Panoramas { get; set; }
     public DbSet<PhotoRating> PhotoRatings { get; set; }
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
@@ -353,6 +354,42 @@ public class MarsVistaDbContext : DbContext
             entity.Property(e => e.ErrorMessage).HasMaxLength(2000);
 
             entity.Property(e => e.CreatedAt)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        // Panorama configuration (pre-computed detection results)
+        modelBuilder.Entity<Panorama>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            // Stable string id the stitch service and ratings resolve against
+            entity.HasIndex(e => e.PanoramaId).IsUnique();
+
+            // Canonical identity: one row per (rover, sol, sequence index)
+            entity.HasIndex(e => new { e.RoverId, e.Sol, e.SequenceIndex }).IsUnique();
+
+            // Query-path indexes: default window (recent sols per rover),
+            // min-photos filter, and coverage sort
+            entity.HasIndex(e => new { e.RoverId, e.Sol });
+            entity.HasIndex(e => e.TotalPhotos);
+            entity.HasIndex(e => e.CoverageDegrees);
+
+            entity.Property(e => e.PanoramaId).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.MarsTimeStart).HasMaxLength(20);
+            entity.Property(e => e.MarsTimeEnd).HasMaxLength(20);
+            entity.Property(e => e.QualityTier).HasMaxLength(20).IsRequired();
+
+            entity.HasOne(e => e.Rover)
+                .WithMany()
+                .HasForeignKey(e => e.RoverId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.Camera)
+                .WithMany()
+                .HasForeignKey(e => e.CameraId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(e => e.DetectedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 

--- a/src/MarsVista.Core/Data/Migrations/20260707183952_AddPanoramasTable.Designer.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260707183952_AddPanoramasTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using MarsVista.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MarsVista.Core.Data.Migrations
 {
     [DbContext(typeof(MarsVistaDbContext))]
-    partial class MarsVistaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707183952_AddPanoramasTable")]
+    partial class AddPanoramasTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1184,75 +1187,6 @@ namespace MarsVista.Core.Data.Migrations
                         .HasDatabaseName("ix_usage_events_user_email_created_at");
 
                     b.ToTable("usage_events", (string)null);
-                });
-
-            modelBuilder.Entity("MarsVista.Core.Entities.UsageEventMonthly", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<DateTime>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
-
-                    b.Property<string>("Endpoint")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("endpoint");
-
-                    b.Property<long>("ErrorCount")
-                        .HasColumnType("bigint")
-                        .HasColumnName("error_count");
-
-                    b.Property<DateTime>("Month")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("month");
-
-                    b.Property<long>("RequestCount")
-                        .HasColumnType("bigint")
-                        .HasColumnName("request_count");
-
-                    b.Property<string>("Tier")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)")
-                        .HasColumnName("tier");
-
-                    b.Property<long>("TotalPhotosReturned")
-                        .HasColumnType("bigint")
-                        .HasColumnName("total_photos_returned");
-
-                    b.Property<long>("TotalResponseTimeMs")
-                        .HasColumnType("bigint")
-                        .HasColumnName("total_response_time_ms");
-
-                    b.Property<DateTime>("UpdatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
-
-                    b.Property<string>("UserEmail")
-                        .IsRequired()
-                        .HasMaxLength(255)
-                        .HasColumnType("character varying(255)")
-                        .HasColumnName("user_email");
-
-                    b.HasKey("Id")
-                        .HasName("pk_usage_events_monthly");
-
-                    b.HasIndex("Month", "UserEmail", "Endpoint", "Tier")
-                        .IsUnique()
-                        .HasDatabaseName("ix_usage_events_monthly_month_user_email_endpoint_tier");
-
-                    b.ToTable("usage_events_monthly", (string)null);
                 });
 
             modelBuilder.Entity("MarsVista.Core.Entities.Camera", b =>

--- a/src/MarsVista.Core/Data/Migrations/20260707183952_AddPanoramasTable.cs
+++ b/src/MarsVista.Core/Data/Migrations/20260707183952_AddPanoramasTable.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MarsVista.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPanoramasTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "panoramas",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    panorama_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    rover_id = table.Column<int>(type: "integer", nullable: false),
+                    sol = table.Column<int>(type: "integer", nullable: false),
+                    sequence_index = table.Column<int>(type: "integer", nullable: false),
+                    camera_id = table.Column<int>(type: "integer", nullable: false),
+                    mars_time_start = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    mars_time_end = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    total_photos = table.Column<int>(type: "integer", nullable: false),
+                    coverage_degrees = table.Column<float>(type: "real", nullable: false),
+                    avg_elevation = table.Column<float>(type: "real", nullable: false),
+                    unique_positions = table.Column<int>(type: "integer", nullable: false),
+                    avg_position_spacing = table.Column<float>(type: "real", nullable: true),
+                    quality_tier = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    is_multi_row = table.Column<bool>(type: "boolean", nullable: false),
+                    elevation_tier_count = table.Column<int>(type: "integer", nullable: false),
+                    azimuth_column_count = table.Column<int>(type: "integer", nullable: false),
+                    min_elevation = table.Column<float>(type: "real", nullable: true),
+                    max_elevation = table.Column<float>(type: "real", nullable: true),
+                    site = table.Column<int>(type: "integer", nullable: true),
+                    drive = table.Column<int>(type: "integer", nullable: true),
+                    coordinate_x = table.Column<float>(type: "real", nullable: true),
+                    coordinate_y = table.Column<float>(type: "real", nullable: true),
+                    coordinate_z = table.Column<float>(type: "real", nullable: true),
+                    photo_ids = table.Column<int[]>(type: "integer[]", nullable: false),
+                    detected_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_panoramas", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_panoramas_cameras_camera_id",
+                        column: x => x.camera_id,
+                        principalTable: "cameras",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_panoramas_rovers_rover_id",
+                        column: x => x.rover_id,
+                        principalTable: "rovers",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_camera_id",
+                table: "panoramas",
+                column: "camera_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_coverage_degrees",
+                table: "panoramas",
+                column: "coverage_degrees");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_panorama_id",
+                table: "panoramas",
+                column: "panorama_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_rover_id_sol",
+                table: "panoramas",
+                columns: new[] { "rover_id", "sol" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_rover_id_sol_sequence_index",
+                table: "panoramas",
+                columns: new[] { "rover_id", "sol", "sequence_index" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_panoramas_total_photos",
+                table: "panoramas",
+                column: "total_photos");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "panoramas");
+        }
+    }
+}

--- a/src/MarsVista.Core/Entities/Panorama.cs
+++ b/src/MarsVista.Core/Entities/Panorama.cs
@@ -1,0 +1,70 @@
+namespace MarsVista.Core.Entities;
+
+/// <summary>
+/// A pre-computed panorama sequence. Materializes the result of
+/// PanoramaDetector so the /api/v2/panoramas endpoints can filter, sort, and
+/// paginate at the database level instead of re-detecting from the photos table
+/// on every request. Rebuilt per (rover, sol) by the scraper; rows for a sol are
+/// deleted and re-inserted idempotently.
+///
+/// Stored derived fields (coverage, quality tier, mosaic geometry, mars times)
+/// are the presentation values ToPanoramaResource would compute at request time,
+/// including the reverse-sweep mars-time normalization, so the table renders
+/// byte-for-byte with the previous detection path.
+/// </summary>
+public class Panorama
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Stable identifier "pano_{rover}_{sol}_{sequenceIndex}". The stitch service
+    /// and panorama ratings resolve against this string; it must match the IDs the
+    /// request-time detection produced (rover-scoped sequence index).
+    /// </summary>
+    public string PanoramaId { get; set; } = string.Empty;
+
+    public int RoverId { get; set; }
+    public Rover Rover { get; set; } = null!;
+
+    public int Sol { get; set; }
+
+    /// <summary>Index of this panorama within its (rover, sol), starting at 0.</summary>
+    public int SequenceIndex { get; set; }
+
+    public int CameraId { get; set; }
+    public Camera Camera { get; set; } = null!;
+
+    // Presentation fields (normalized so start <= end for reverse sweeps)
+    public string? MarsTimeStart { get; set; }
+    public string? MarsTimeEnd { get; set; }
+
+    public int TotalPhotos { get; set; }
+    public float CoverageDegrees { get; set; }
+    public float AvgElevation { get; set; }
+    public int UniquePositions { get; set; }
+    public float? AvgPositionSpacing { get; set; }
+
+    /// <summary>full / wide / half / partial (PanoramaDetector.GetQualityTier).</summary>
+    public string QualityTier { get; set; } = string.Empty;
+
+    // Mosaic geometry
+    public bool IsMultiRow { get; set; }
+    public int ElevationTierCount { get; set; } = 1;
+    public int AzimuthColumnCount { get; set; }
+
+    /// <summary>Elevation extremes; populated only for multi-row mosaics.</summary>
+    public float? MinElevation { get; set; }
+    public float? MaxElevation { get; set; }
+
+    // Location (from the first photo of the sequence)
+    public int? Site { get; set; }
+    public int? Drive { get; set; }
+    public float? CoordinateX { get; set; }
+    public float? CoordinateY { get; set; }
+    public float? CoordinateZ { get; set; }
+
+    /// <summary>Constituent photo ids, used to load photos for the detail endpoint.</summary>
+    public int[] PhotoIds { get; set; } = Array.Empty<int>();
+
+    public DateTime DetectedAt { get; set; }
+}

--- a/src/MarsVista.Core/Services/PanoramaBackfillRunner.cs
+++ b/src/MarsVista.Core/Services/PanoramaBackfillRunner.cs
@@ -1,0 +1,93 @@
+using MarsVista.Core.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace MarsVista.Core.Services;
+
+/// <summary>
+/// Summary of a backfill run.
+/// </summary>
+public record PanoramaBackfillSummary(int TotalPairs, int Processed, int PanoramasWritten, int Failures);
+
+/// <summary>
+/// One-off backfill of the panoramas table: enumerates every (rover, sol) that
+/// has candidate panorama photos and rebuilds each. Idempotent and resumable -
+/// re-running simply rebuilds every sol again to the same result. Run from the
+/// scraper's PANORAMA_BACKFILL mode.
+/// </summary>
+public class PanoramaBackfillRunner
+{
+    private readonly MarsVistaDbContext _context;
+    private readonly IPanoramaTableBuilder _builder;
+    private readonly ILogger<PanoramaBackfillRunner> _logger;
+
+    public PanoramaBackfillRunner(
+        MarsVistaDbContext context,
+        IPanoramaTableBuilder builder,
+        ILogger<PanoramaBackfillRunner> logger)
+    {
+        _context = context;
+        _builder = builder;
+        _logger = logger;
+    }
+
+    public async Task<PanoramaBackfillSummary> RunAsync(
+        IReadOnlyList<int>? roverIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        var candidates = _context.Photos
+            .Where(p => p.Site.HasValue &&
+                        p.Drive.HasValue &&
+                        p.MastAz.HasValue &&
+                        p.MastEl.HasValue &&
+                        p.SpacecraftClock.HasValue &&
+                        PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name));
+
+        if (roverIds is { Count: > 0 })
+        {
+            candidates = candidates.Where(p => roverIds.Contains(p.RoverId));
+        }
+
+        var pairs = await candidates
+            .Select(p => new { p.RoverId, p.Sol })
+            .Distinct()
+            .OrderBy(x => x.RoverId)
+            .ThenBy(x => x.Sol)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogInformation("Panorama backfill starting: {PairCount} (rover, sol) pairs to process", pairs.Count);
+
+        var processed = 0;
+        var panoramas = 0;
+        var failures = 0;
+
+        foreach (var pair in pairs)
+        {
+            try
+            {
+                panoramas += await _builder.RebuildSolAsync(pair.RoverId, pair.Sol, cancellationToken);
+                processed++;
+
+                if (processed % 100 == 0)
+                {
+                    _logger.LogInformation(
+                        "Backfill progress: {Processed}/{Total} sols, {Panoramas} panoramas written",
+                        processed, pairs.Count, panoramas);
+                }
+            }
+            catch (Exception ex)
+            {
+                // One bad sol must not abort the whole backfill; it can be retried by
+                // simply re-running (idempotent per sol).
+                failures++;
+                _logger.LogError(ex, "Backfill failed for rover {RoverId} sol {Sol}", pair.RoverId, pair.Sol);
+            }
+        }
+
+        _logger.LogInformation(
+            "Panorama backfill complete: {Processed}/{Total} sols processed, {Panoramas} panoramas written, {Failures} failures",
+            processed, pairs.Count, panoramas, failures);
+
+        return new PanoramaBackfillSummary(pairs.Count, processed, panoramas, failures);
+    }
+}

--- a/src/MarsVista.Core/Services/PanoramaDetector.cs
+++ b/src/MarsVista.Core/Services/PanoramaDetector.cs
@@ -1,0 +1,405 @@
+using MarsVista.Core.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace MarsVista.Core.Services;
+
+/// <summary>
+/// Represents a detected panorama sequence: a set of photos that together form
+/// a single- or multi-row panoramic observation.
+/// </summary>
+public class PanoramaSequence
+{
+    public List<Photo> Photos { get; set; } = new();
+    public int Index { get; set; }
+    public bool IsMultiRow { get; set; }
+    public int ElevationTierCount { get; set; } = 1;
+    public int AzimuthColumnCount { get; set; }
+    public float MinElevation { get; set; }
+    public float MaxElevation { get; set; }
+}
+
+/// <summary>
+/// Pure panorama-detection logic shared by the API (request-time detection) and
+/// the scraper (pre-compute into the panoramas table). Detects panoramic
+/// sequences from candidate photos based on location, time contiguity, and
+/// camera telemetry. Depends only on Core entities and ILogger - no DbContext,
+/// no DTOs.
+/// </summary>
+public class PanoramaDetector
+{
+    // Panorama detection parameters
+    public const float MinAzimuthRangeDegrees = 30.0f; // At least 30 degrees coverage
+    public const int MinPhotosForPanorama = 3; // At least 3 photos
+    public const int MinUniquePositions = 3; // At least 3 unique azimuth positions (stitchable)
+    public const float MaxTimeDeltaSeconds = 300.0f; // Max 5 minutes between photos
+
+    // Multi-row mosaic detection parameters
+    public const float ElevationTierGapDegrees = 5.0f; // Min gap between sorted elevations to start a new tier
+    public const float MinGridCompleteness = 0.40f; // Multi-row mosaic must fill 40% of grid cells
+
+    // Only cameras designed for panoramic imaging — excludes spectrometers (ChemCam, SuperCam RMI),
+    // hazard cameras (fixed FOV), arm cameras (MAHLI, SHERLOC), and descent/EDL cameras
+    public static readonly HashSet<string> PanoramicCameras = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "MAST", "NAVCAM",                               // Curiosity
+        "MCZ_LEFT", "MCZ_RIGHT", "NAVCAM_LEFT", "NAVCAM_RIGHT", // Perseverance
+        "PANCAM"                                         // Opportunity, Spirit
+    };
+
+    private readonly ILogger _logger;
+
+    public PanoramaDetector(ILogger<PanoramaDetector> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Optimized panorama detection that processes sol batches.
+    /// Groups photos by location/camera, splits on time gaps, then classifies
+    /// as single-row or multi-row based on elevation tier clustering.
+    /// </summary>
+    public List<PanoramaSequence> DetectPanoramasOptimized(List<Photo> photos, int minPhotos, ref int panoramaIndex)
+    {
+        var panoramas = new List<PanoramaSequence>();
+
+        // Group by rover, sol, site, drive, and camera
+        var allGroups = photos
+            .GroupBy(p => new
+            {
+                p.RoverId,
+                p.Sol,
+                Site = p.Site ?? 0,
+                Drive = p.Drive ?? 0,
+                p.CameraId
+            })
+            .ToList();
+
+        _logger.LogDebug("DetectPanoramasOptimized: {PhotoCount} photos, {GroupCount} total groups, minPhotos={MinPhotos}",
+            photos.Count, allGroups.Count, minPhotos);
+
+        var groups = allGroups
+            .Where(g => g.Count() >= minPhotos)
+            .OrderBy(g => g.Key.RoverId)
+            .ThenBy(g => g.Key.Sol)
+            .ThenBy(g => g.Key.Site)
+            .ThenBy(g => g.Key.Drive)
+            .ThenBy(g => g.Key.CameraId)
+            .ToList();
+
+        _logger.LogDebug("DetectPanoramasOptimized: {QualifiedGroupCount} groups with >= {MinPhotos} photos",
+            groups.Count, minPhotos);
+
+        foreach (var group in groups)
+        {
+            var groupPhotos = group.OrderBy(p => p.SpacecraftClock).ThenBy(p => p.MastEl).ToList();
+
+            _logger.LogDebug("Processing group: CameraId={CameraId}, Site={Site}, Drive={Drive}, {PhotoCount} photos",
+                group.Key.CameraId, group.Key.Site, group.Key.Drive, groupPhotos.Count);
+
+            // Step 1: Split into time-contiguous blocks (no elevation check)
+            var blocks = BuildTimeContiguousBlocks(groupPhotos);
+
+            // Step 2: For each block, cluster elevations and classify
+            foreach (var block in blocks)
+            {
+                if (block.Count < minPhotos)
+                    continue;
+
+                var tiers = ClusterElevationTiers(block);
+
+                if (tiers.Count <= 1)
+                {
+                    // Single-row: validate with existing criteria
+                    if (IsValidPanorama(block))
+                    {
+                        var uniqueAz = block
+                            .Select(p => Math.Round(p.MastAz ?? 0))
+                            .Distinct()
+                            .Count();
+
+                        panoramas.Add(new PanoramaSequence
+                        {
+                            Photos = new List<Photo>(block),
+                            Index = panoramaIndex++,
+                            IsMultiRow = false,
+                            ElevationTierCount = 1,
+                            AzimuthColumnCount = uniqueAz
+                        });
+                    }
+                }
+                else
+                {
+                    // Multi-row candidate: validate with mosaic criteria
+                    if (IsValidMosaic(block, tiers, out var mosaicMetrics))
+                    {
+                        var elevations = block.Select(p => p.MastEl ?? 0).ToList();
+
+                        panoramas.Add(new PanoramaSequence
+                        {
+                            Photos = new List<Photo>(block),
+                            Index = panoramaIndex++,
+                            IsMultiRow = true,
+                            ElevationTierCount = tiers.Count,
+                            AzimuthColumnCount = mosaicMetrics!.MaxColumnsPerTier,
+                            MinElevation = elevations.Min(),
+                            MaxElevation = elevations.Max()
+                        });
+                    }
+                    else
+                    {
+                        // Fallback: try each tier as a single-row panorama.
+                        // A block with multiple elevation tiers that fails mosaic validation
+                        // may still contain valid single-row panoramas within individual tiers.
+                        foreach (var tier in tiers)
+                        {
+                            var tierPhotos = block
+                                .Where(p => GetElevationTier(p.MastEl ?? 0, tiers) == tier)
+                                .OrderBy(p => p.SpacecraftClock)
+                                .ThenBy(p => p.MastEl)
+                                .ToList();
+
+                            if (tierPhotos.Count >= minPhotos && IsValidPanorama(tierPhotos))
+                            {
+                                var uniqueAz = tierPhotos
+                                    .Select(p => Math.Round(p.MastAz ?? 0))
+                                    .Distinct()
+                                    .Count();
+
+                                panoramas.Add(new PanoramaSequence
+                                {
+                                    Photos = new List<Photo>(tierPhotos),
+                                    Index = panoramaIndex++,
+                                    IsMultiRow = false,
+                                    ElevationTierCount = 1,
+                                    AzimuthColumnCount = uniqueAz
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return panoramas;
+    }
+
+    /// <summary>
+    /// Detect panorama sequences from a list of photos (single sol, index from 0).
+    /// </summary>
+    public List<PanoramaSequence> DetectPanoramas(List<Photo> photos, int minPhotos)
+    {
+        var panoramaIndex = 0;
+        return DetectPanoramasOptimized(photos, minPhotos, ref panoramaIndex);
+    }
+
+    /// <summary>
+    /// Split photos into time-contiguous blocks using only the time gap threshold.
+    /// No elevation check — multi-row mosaics sweep across elevation tiers continuously.
+    /// </summary>
+    private List<List<Photo>> BuildTimeContiguousBlocks(List<Photo> orderedPhotos)
+    {
+        var blocks = new List<List<Photo>>();
+        var current = new List<Photo>();
+
+        for (int i = 0; i < orderedPhotos.Count; i++)
+        {
+            if (current.Count == 0)
+            {
+                current.Add(orderedPhotos[i]);
+            }
+            else
+            {
+                var timeDelta = (orderedPhotos[i].SpacecraftClock ?? 0) - (current[^1].SpacecraftClock ?? 0);
+                if (timeDelta <= MaxTimeDeltaSeconds && timeDelta >= 0)
+                {
+                    current.Add(orderedPhotos[i]);
+                }
+                else
+                {
+                    blocks.Add(current);
+                    current = new List<Photo> { orderedPhotos[i] };
+                }
+            }
+        }
+
+        if (current.Count > 0)
+            blocks.Add(current);
+
+        return blocks;
+    }
+
+    /// <summary>
+    /// Cluster unique elevations into tiers using adaptive gap-based grouping.
+    /// Sorts unique rounded elevations, splits when consecutive gap >= ElevationTierGapDegrees.
+    /// Returns the center value of each tier.
+    /// </summary>
+    private static List<float> ClusterElevationTiers(List<Photo> photos)
+    {
+        var uniqueElevations = photos
+            .Select(p => MathF.Round(p.MastEl ?? 0))
+            .Distinct()
+            .OrderBy(e => e)
+            .ToList();
+
+        if (uniqueElevations.Count == 0)
+            return new List<float>();
+
+        var tiers = new List<float>();
+        var currentTier = new List<float> { uniqueElevations[0] };
+
+        for (int i = 1; i < uniqueElevations.Count; i++)
+        {
+            if (uniqueElevations[i] - uniqueElevations[i - 1] >= ElevationTierGapDegrees)
+            {
+                // Gap found — finalize current tier, start new one
+                tiers.Add(currentTier.Average());
+                currentTier = new List<float> { uniqueElevations[i] };
+            }
+            else
+            {
+                currentTier.Add(uniqueElevations[i]);
+            }
+        }
+
+        tiers.Add(currentTier.Average());
+        return tiers;
+    }
+
+    /// <summary>
+    /// Map a photo's elevation to its nearest tier center value.
+    /// </summary>
+    private static float GetElevationTier(float elevation, List<float> tiers)
+    {
+        return tiers.OrderBy(t => Math.Abs(t - elevation)).First();
+    }
+
+    private record MosaicMetrics(int MaxColumnsPerTier, int FilledCells, float Completeness);
+
+    /// <summary>
+    /// Validate a multi-row mosaic: azimuth range >= 30°, unique positions >= 3,
+    /// and grid completeness >= 40%. Returns computed grid metrics on success.
+    /// </summary>
+    private bool IsValidMosaic(List<Photo> photos, List<float> tiers, out MosaicMetrics? metrics)
+    {
+        metrics = null;
+
+        if (photos.Count < MinPhotosForPanorama)
+            return false;
+
+        var azimuths = photos.Select(p => p.MastAz ?? 0).ToList();
+        var azimuthRange = azimuths.Max() - azimuths.Min();
+
+        if (azimuthRange < MinAzimuthRangeDegrees)
+        {
+            _logger.LogDebug("IsValidMosaic: FAILED - azimuth range {Range}° < {Min}°", azimuthRange, MinAzimuthRangeDegrees);
+            return false;
+        }
+
+        var uniquePositions = photos
+            .Select(p => Math.Round(p.MastAz ?? 0))
+            .Distinct()
+            .Count();
+
+        if (uniquePositions < MinUniquePositions)
+        {
+            _logger.LogDebug("IsValidMosaic: FAILED - {UniquePos} unique positions < {Min}", uniquePositions, MinUniquePositions);
+            return false;
+        }
+
+        // Compute per-tier column counts in one pass
+        var tierColumnCounts = tiers.Select(tier =>
+        {
+            var tierPhotos = photos.Where(p => GetElevationTier(p.MastEl ?? 0, tiers) == tier);
+            return tierPhotos.Select(p => Math.Round(p.MastAz ?? 0)).Distinct().Count();
+        }).ToList();
+
+        var maxColumnsPerTier = tierColumnCounts.Max();
+
+        if (maxColumnsPerTier < MinUniquePositions)
+        {
+            _logger.LogDebug("IsValidMosaic: FAILED - max {Cols} columns per tier < {Min} required for stitching",
+                maxColumnsPerTier, MinUniquePositions);
+            return false;
+        }
+
+        // At least 2 tiers must have meaningful column counts for a real multi-row mosaic.
+        // One dense tier + sparse single-shot tiers is not a mosaic — it's a sweep with
+        // unrelated observations at different elevations (e.g., bracketed bursts).
+        var tiersWithEnoughColumns = tierColumnCounts.Count(c => c >= MinUniquePositions);
+        if (tiersWithEnoughColumns < 2)
+        {
+            _logger.LogDebug("IsValidMosaic: FAILED - only {Count} tier(s) have >= {Min} columns (need at least 2)",
+                tiersWithEnoughColumns, MinUniquePositions);
+            return false;
+        }
+
+        // Grid completeness: how many (tier, azimuth) cells are filled vs total possible
+        var totalCells = tiers.Count * maxColumnsPerTier;
+        var filledCells = tierColumnCounts.Sum();
+        var completeness = (float)filledCells / totalCells;
+
+        if (completeness < MinGridCompleteness)
+        {
+            _logger.LogDebug("IsValidMosaic: FAILED - grid completeness {Completeness:P0} < {Min:P0}",
+                completeness, MinGridCompleteness);
+            return false;
+        }
+
+        _logger.LogDebug("IsValidMosaic: PASSED - {Count} photos, {Tiers} tiers, {Range}° azimuth, {Completeness:P0} grid fill",
+            photos.Count, tiers.Count, azimuthRange, completeness);
+        metrics = new MosaicMetrics(maxColumnsPerTier, filledCells, completeness);
+        return true;
+    }
+
+    /// <summary>
+    /// Check if a sequence qualifies as a panorama
+    /// </summary>
+    private bool IsValidPanorama(List<Photo> photos)
+    {
+        if (photos.Count < MinPhotosForPanorama)
+        {
+            _logger.LogDebug("IsValidPanorama: FAILED - {Count} photos < {Min} required",
+                photos.Count, MinPhotosForPanorama);
+            return false;
+        }
+
+        // Check azimuth range
+        var azimuths = photos.Select(p => p.MastAz ?? 0).ToList();
+        var azimuthRange = azimuths.Max() - azimuths.Min();
+
+        if (azimuthRange < MinAzimuthRangeDegrees)
+        {
+            _logger.LogDebug("IsValidPanorama: FAILED - azimuth range {Range}° < {Min}° required",
+                azimuthRange, MinAzimuthRangeDegrees);
+            return false;
+        }
+
+        // Count unique positions (round to nearest degree to handle float precision)
+        var uniquePositions = photos
+            .Select(p => Math.Round(p.MastAz ?? 0))
+            .Distinct()
+            .Count();
+
+        if (uniquePositions < MinUniquePositions)
+        {
+            _logger.LogDebug("IsValidPanorama: FAILED - {UniquePos} unique positions < {Min} required",
+                uniquePositions, MinUniquePositions);
+            return false;
+        }
+
+        _logger.LogDebug("IsValidPanorama: PASSED - {Count} photos, {Range}° coverage, {UniquePos} unique positions",
+            photos.Count, azimuthRange, uniquePositions);
+        return true;
+    }
+
+    /// <summary>
+    /// Determine quality tier based on coverage and unique positions
+    /// </summary>
+    public static string GetQualityTier(float coverageDegrees, int uniquePositions)
+    {
+        if (coverageDegrees >= 300 && uniquePositions >= 10) return "full";
+        if (coverageDegrees >= 200 && uniquePositions >= 7) return "wide";
+        if (coverageDegrees >= 120 && uniquePositions >= 5) return "half";
+        return "partial";
+    }
+}

--- a/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
+++ b/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
@@ -1,0 +1,196 @@
+using MarsVista.Core.Data;
+using MarsVista.Core.Entities;
+using MarsVista.Core.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace MarsVista.Core.Services;
+
+/// <summary>
+/// Populates the panoramas table by running <see cref="PanoramaDetector"/> over
+/// a single (rover, sol) and materializing the presentation values that
+/// ToPanoramaResource computes at request time. Used by the scraper's backfill
+/// mode and its daily incremental refresh.
+/// </summary>
+public interface IPanoramaTableBuilder
+{
+    /// <summary>
+    /// Rebuilds all panorama rows for one (rover, sol): deletes the existing rows
+    /// and inserts freshly detected ones in a single transaction. Idempotent -
+    /// rebuilding an unchanged sol produces identical rows. Returns the number of
+    /// panoramas written.
+    /// </summary>
+    Task<int> RebuildSolAsync(int roverId, int sol, CancellationToken cancellationToken = default);
+}
+
+public class PanoramaTableBuilder : IPanoramaTableBuilder
+{
+    private readonly MarsVistaDbContext _context;
+    private readonly PanoramaDetector _detector;
+    private readonly ILogger<PanoramaTableBuilder> _logger;
+
+    public PanoramaTableBuilder(
+        MarsVistaDbContext context,
+        PanoramaDetector detector,
+        ILogger<PanoramaTableBuilder> logger)
+    {
+        _context = context;
+        _detector = detector;
+        _logger = logger;
+    }
+
+    public async Task<int> RebuildSolAsync(int roverId, int sol, CancellationToken cancellationToken = default)
+    {
+        // Candidate photos, ordered exactly as the request-time detail path
+        // (DetectPanoramaSequenceByIdAsync) so sequence indices - and therefore
+        // panorama ids - match the ids the stitch service and ratings resolve against.
+        var photos = await _context.Photos
+            .Where(p => p.RoverId == roverId &&
+                        p.Sol == sol &&
+                        p.Site.HasValue &&
+                        p.Drive.HasValue &&
+                        p.MastAz.HasValue &&
+                        p.MastEl.HasValue &&
+                        p.SpacecraftClock.HasValue &&
+                        PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name))
+            .Include(p => p.Rover)
+            .Include(p => p.Camera)
+            .OrderBy(p => p.RoverId)
+            .ThenBy(p => p.Site)
+            .ThenBy(p => p.Drive)
+            .ThenBy(p => p.SpacecraftClock)
+            .ThenBy(p => p.MastEl)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        var sequences = _detector.DetectPanoramas(photos, PanoramaDetector.MinPhotosForPanorama);
+        var rows = sequences.Select(seq => MapToEntity(seq, roverId, sol)).ToList();
+
+        await WarnOnOrphanedStitchesAsync(roverId, sol, rows, cancellationToken);
+
+        // Idempotent replace: drop the sol's existing rows and insert the fresh
+        // set atomically so a reader never sees a half-rebuilt sol.
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+        await _context.Panoramas
+            .Where(p => p.RoverId == roverId && p.Sol == sol)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (rows.Count > 0)
+        {
+            _context.Panoramas.AddRange(rows);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogDebug("Rebuilt {Count} panoramas for rover {RoverId} sol {Sol}", rows.Count, roverId, sol);
+        return rows.Count;
+    }
+
+    /// <summary>
+    /// Warn when a panorama id that an existing stitched_panoramas row points at
+    /// no longer appears after a rebuild - the stitched image would be orphaned.
+    /// </summary>
+    private async Task WarnOnOrphanedStitchesAsync(
+        int roverId, int sol, List<Panorama> rows, CancellationToken cancellationToken)
+    {
+        var priorStitchedIds = await _context.Panoramas
+            .Where(p => p.RoverId == roverId && p.Sol == sol)
+            .Join(_context.StitchedPanoramas, p => p.PanoramaId, s => s.PanoramaId, (p, s) => p.PanoramaId)
+            .ToListAsync(cancellationToken);
+
+        var newIds = rows.Select(r => r.PanoramaId).ToHashSet();
+        foreach (var orphaned in priorStitchedIds.Where(id => !newIds.Contains(id)))
+        {
+            _logger.LogWarning(
+                "Rebuild of rover {RoverId} sol {Sol} dropped panorama {PanoramaId}, which a stitched_panoramas row references - the stitched image is now orphaned",
+                roverId, sol, orphaned);
+        }
+    }
+
+    private static Panorama MapToEntity(PanoramaSequence sequence, int roverId, int sol)
+    {
+        var firstPhoto = sequence.Photos.First();
+        var lastPhoto = sequence.Photos.Last();
+        var rover = firstPhoto.Rover.Name.ToLowerInvariant();
+        var panoramaId = $"pano_{rover}_{sol}_{sequence.Index}";
+
+        var azimuths = sequence.Photos.Select(p => p.MastAz ?? 0).ToList();
+        var coverageDegrees = azimuths.Max() - azimuths.Min();
+
+        var uniqueAzimuths = sequence.Photos
+            .Select(p => Math.Round(p.MastAz ?? 0))
+            .Distinct()
+            .OrderBy(a => a)
+            .ToList();
+        var uniquePositions = uniqueAzimuths.Count;
+
+        float? avgPositionSpacing = null;
+        if (uniquePositions > 1)
+        {
+            var totalSpacing = 0.0;
+            for (int i = 1; i < uniqueAzimuths.Count; i++)
+            {
+                totalSpacing += uniqueAzimuths[i] - uniqueAzimuths[i - 1];
+            }
+            avgPositionSpacing = (float)(totalSpacing / (uniquePositions - 1));
+        }
+
+        var quality = PanoramaDetector.GetQualityTier(coverageDegrees, uniquePositions);
+
+        // Mars time range, normalized so start <= end for reverse-sweep panoramas
+        string? marsTimeStart = null;
+        string? marsTimeEnd = null;
+        TimeSpan parsedStart = default, parsedEnd = default;
+        bool hasStart = !string.IsNullOrEmpty(firstPhoto.DateTakenMars) &&
+            MarsTimeHelper.TryExtractTimeFromTimestamp(firstPhoto.DateTakenMars, out parsedStart);
+        bool hasEnd = !string.IsNullOrEmpty(lastPhoto.DateTakenMars) &&
+            MarsTimeHelper.TryExtractTimeFromTimestamp(lastPhoto.DateTakenMars, out parsedEnd);
+        if (hasStart) marsTimeStart = MarsTimeHelper.FormatMarsTime(parsedStart);
+        if (hasEnd) marsTimeEnd = MarsTimeHelper.FormatMarsTime(parsedEnd);
+        if (hasStart && hasEnd && parsedStart > parsedEnd)
+        {
+            (marsTimeStart, marsTimeEnd) = (marsTimeEnd, marsTimeStart);
+        }
+
+        var avgElevation = sequence.Photos.Average(p => p.MastEl ?? 0);
+
+        float? coordinateX = null, coordinateY = null, coordinateZ = null;
+        if (!string.IsNullOrEmpty(firstPhoto.Xyz) &&
+            MarsTimeHelper.TryParseXYZ(firstPhoto.Xyz, out var parsedXyz))
+        {
+            coordinateX = parsedXyz.X;
+            coordinateY = parsedXyz.Y;
+            coordinateZ = parsedXyz.Z;
+        }
+
+        return new Panorama
+        {
+            PanoramaId = panoramaId,
+            RoverId = roverId,
+            Sol = sol,
+            SequenceIndex = sequence.Index,
+            CameraId = firstPhoto.CameraId,
+            MarsTimeStart = marsTimeStart,
+            MarsTimeEnd = marsTimeEnd,
+            TotalPhotos = sequence.Photos.Count,
+            CoverageDegrees = coverageDegrees,
+            AvgElevation = avgElevation,
+            UniquePositions = uniquePositions,
+            AvgPositionSpacing = avgPositionSpacing,
+            QualityTier = quality,
+            IsMultiRow = sequence.IsMultiRow,
+            ElevationTierCount = sequence.ElevationTierCount,
+            AzimuthColumnCount = sequence.AzimuthColumnCount,
+            MinElevation = sequence.IsMultiRow ? sequence.MinElevation : null,
+            MaxElevation = sequence.IsMultiRow ? sequence.MaxElevation : null,
+            Site = firstPhoto.Site,
+            Drive = firstPhoto.Drive,
+            CoordinateX = coordinateX,
+            CoordinateY = coordinateY,
+            CoordinateZ = coordinateZ,
+            PhotoIds = sequence.Photos.Select(p => p.Id).ToArray(),
+        };
+    }
+}

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -77,6 +77,12 @@ try
     builder.Services.AddScoped<MarsVista.Core.Services.IUsageEventRetentionService,
         MarsVista.Core.Services.UsageEventRetentionService>();
 
+    // Panorama pre-compute services (backfill mode + daily incremental refresh)
+    builder.Services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
+    builder.Services.AddScoped<MarsVista.Core.Services.IPanoramaTableBuilder,
+        MarsVista.Core.Services.PanoramaTableBuilder>();
+    builder.Services.AddScoped<MarsVista.Core.Services.PanoramaBackfillRunner>();
+
     // Configure scraper schedule options
     builder.Services.Configure<ScraperScheduleOptions>(
         builder.Configuration.GetSection(ScraperScheduleOptions.SectionName));
@@ -91,6 +97,37 @@ try
         Log.Information("Applying pending database migrations...");
         await dbContext.Database.MigrateAsync();
         Log.Information("Database migrations complete");
+    }
+
+    // Panorama backfill mode: populate the panoramas table for every existing
+    // (rover, sol) and exit without scraping. Run as a one-off job.
+    var backfillMode = Environment.GetEnvironmentVariable("PANORAMA_BACKFILL");
+    if (string.Equals(backfillMode, "true", StringComparison.OrdinalIgnoreCase))
+    {
+        List<int>? backfillRoverIds = null;
+        var roverIdsEnv = Environment.GetEnvironmentVariable("BACKFILL_ROVER_IDS");
+        if (!string.IsNullOrWhiteSpace(roverIdsEnv))
+        {
+            backfillRoverIds = roverIdsEnv
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(s => int.TryParse(s, out _))
+                .Select(int.Parse)
+                .ToList();
+        }
+
+        Log.Information("PANORAMA_BACKFILL=true - running panorama table backfill (rovers: {Rovers})",
+            backfillRoverIds != null ? string.Join(", ", backfillRoverIds) : "all");
+
+        using var backfillScope = host.Services.CreateScope();
+        var runner = backfillScope.ServiceProvider
+            .GetRequiredService<MarsVista.Core.Services.PanoramaBackfillRunner>();
+        var summary = await runner.RunAsync(backfillRoverIds);
+
+        Log.Information(
+            "Panorama backfill finished: {Processed}/{Total} sols processed, {Panoramas} panoramas written, {Failures} failures",
+            summary.Processed, summary.TotalPairs, summary.PanoramasWritten, summary.Failures);
+        Environment.ExitCode = summary.Failures == 0 ? 0 : 1;
+        return;
     }
 
     // Get configuration

--- a/tests/MarsVista.Api.Tests/Integration/PanoramaBackfillRunnerTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/PanoramaBackfillRunnerTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MarsVista.Core.Entities;
+using MarsVista.Core.Services;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// Verifies the backfill runner enumerates every (rover, sol) with candidate
+/// panorama photos and rebuilds each, honouring an optional rover filter. The
+/// runner touches only the database - there are no NASA HTTP calls in this path.
+/// </summary>
+public class PanoramaBackfillRunnerTests : IntegrationTestBase
+{
+    private PanoramaBackfillRunner _runner = null!;
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        var detector = new PanoramaDetector(NullLogger<PanoramaDetector>.Instance);
+        var builder = new PanoramaTableBuilder(DbContext, detector, NullLogger<PanoramaTableBuilder>.Instance);
+        _runner = new PanoramaBackfillRunner(DbContext, builder, NullLogger<PanoramaBackfillRunner>.Instance);
+
+        var now = DateTime.UtcNow;
+
+        // A detectable panorama on Curiosity (rover 1) sol 1000.
+        AddPanoramaPhotos(roverId: 1, cameraId: 2, sol: 1000, prefix: "CUR1000");
+        // A second on Curiosity sol 1001.
+        AddPanoramaPhotos(roverId: 1, cameraId: 2, sol: 1001, prefix: "CUR1001");
+        // One on Perseverance (rover 2) sol 50 - camera 3 is NAVCAM (panoramic).
+        AddPanoramaPhotos(roverId: 2, cameraId: 3, sol: 50, prefix: "PER50");
+
+        // A non-candidate photo (no telemetry) must not create a pair.
+        DbContext.Photos.Add(new Photo
+        {
+            NasaId = "NO_TELEMETRY", Sol = 2000,
+            EarthDate = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            DateTakenUtc = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ImgSrcSmall = "s", ImgSrcMedium = "m", ImgSrcLarge = "l", ImgSrcFull = "f",
+            RoverId = 1, CameraId = 2,
+            CreatedAt = now, UpdatedAt = now,
+        });
+
+        await DbContext.SaveChangesAsync();
+    }
+
+    private void AddPanoramaPhotos(int roverId, int cameraId, int sol, string prefix)
+    {
+        var now = DateTime.UtcNow;
+        for (int i = 0; i < 5; i++)
+        {
+            DbContext.Photos.Add(new Photo
+            {
+                NasaId = $"{prefix}_{i:D4}",
+                Sol = sol,
+                EarthDate = new DateTime(2015, 5, 30, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 5, 30, 10, i, 0, DateTimeKind.Utc),
+                DateTakenMars = $"Sol-{sol}M14:0{i}:00",
+                ImgSrcSmall = "s", ImgSrcMedium = "m", ImgSrcLarge = "l", ImgSrcFull = "f",
+                Site = 79, Drive = 1204,
+                MastAz = 45.0f + (i * 10.0f),
+                MastEl = -10.0f,
+                SpacecraftClock = 813073000.0f + (i * 100.0f),
+                RoverId = roverId, CameraId = cameraId,
+                CreatedAt = now, UpdatedAt = now,
+            });
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_RebuildsEveryCandidatePair()
+    {
+        var summary = await _runner.RunAsync();
+
+        summary.TotalPairs.Should().Be(3, "three (rover, sol) pairs have candidate photos");
+        summary.Processed.Should().Be(3);
+        summary.Failures.Should().Be(0);
+        summary.PanoramasWritten.Should().Be(3, "each pair forms one single-row panorama");
+
+        DbContext.Panoramas.AsEnumerable().Select(p => p.Sol).OrderBy(s => s)
+            .Should().Equal(50, 1000, 1001);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithRoverFilter_OnlyProcessesThatRover()
+    {
+        var summary = await _runner.RunAsync(new[] { 2 });
+
+        summary.TotalPairs.Should().Be(1, "only Perseverance (rover 2) is in scope");
+        summary.PanoramasWritten.Should().Be(1);
+        DbContext.Panoramas.AsEnumerable().Should().OnlyContain(p => p.RoverId == 2);
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MarsVista.Api.Services.V2;
+using MarsVista.Core.Entities;
+using MarsVista.Core.Services;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// Verifies the pre-compute builder produces rows whose stored presentation
+/// values match the live request-time detection path (so the read-path cutover
+/// is byte-for-byte), that rebuilding is idempotent, and that a rebuild which
+/// drops a stitched-referenced panorama id logs a warning instead of throwing.
+/// </summary>
+public class PanoramaTableBuilderTests : IntegrationTestBase
+{
+    private const int RoverId = 1;   // Curiosity (seeded by base)
+    private const int Sol = 1000;
+
+    private IPanoramaService _panoramaService = null!;
+    private PanoramaTableBuilder _builder = null!;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IPhotoQueryServiceV2, PhotoQueryServiceV2>();
+        services.AddScoped<PanoramaDetector>();
+        services.AddScoped<IPanoramaService, PanoramaService>();
+    }
+
+    protected override async Task SeedAdditionalDataAsync()
+    {
+        _panoramaService = ServiceProvider.GetRequiredService<IPanoramaService>();
+        _builder = new PanoramaTableBuilder(
+            DbContext,
+            ServiceProvider.GetRequiredService<PanoramaDetector>(),
+            NullLogger<PanoramaTableBuilder>.Instance);
+
+        var now = DateTime.UtcNow;
+        // Single-row panorama: 5 photos, azimuth 45..85 (40° range, 5 positions), same elevation.
+        for (int i = 0; i < 5; i++)
+        {
+            DbContext.Photos.Add(new Photo
+            {
+                NasaId = $"NRF_1000_{i:D4}",
+                Sol = Sol,
+                EarthDate = new DateTime(2015, 5, 30, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 5, 30, 10, i, 0, DateTimeKind.Utc),
+                DateTakenMars = $"Sol-1000M14:0{i}:00",
+                ImgSrcSmall = "s", ImgSrcMedium = "m", ImgSrcLarge = "l", ImgSrcFull = "f",
+                Site = 79,
+                Drive = 1204,
+                MastAz = 45.0f + (i * 10.0f),
+                MastEl = -10.0f,
+                SpacecraftClock = 813073000.0f + (i * 100.0f),
+                Xyz = "{\"x\": 35.4362, \"y\": 22.5714, \"z\": -9.46445}",
+                RoverId = RoverId,
+                CameraId = 2, // MAST
+                CreatedAt = now, UpdatedAt = now,
+            });
+        }
+        await DbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task BuilderRow_MatchesLiveDetection()
+    {
+        var live = await _panoramaService.GetPanoramasAsync(
+            rovers: "curiosity", solMin: Sol, solMax: Sol, pageSize: 50);
+        live.Data.Should().NotBeEmpty("the seed forms a detectable panorama");
+
+        await _builder.RebuildSolAsync(RoverId, Sol);
+
+        foreach (var dto in live.Data!)
+        {
+            var row = DbContext.Panoramas.AsEnumerable()
+                .Single(p => p.PanoramaId == dto.Id);
+            var attrs = dto.Attributes!;
+
+            row.TotalPhotos.Should().Be(attrs.TotalPhotos);
+            row.CoverageDegrees.Should().Be(attrs.CoverageDegrees!.Value);
+            row.UniquePositions.Should().Be(attrs.UniquePositions);
+            row.AvgPositionSpacing.Should().Be(attrs.AvgPositionSpacing);
+            row.AvgElevation.Should().Be(attrs.AvgElevation!.Value);
+            row.QualityTier.Should().Be(attrs.Quality);
+            row.IsMultiRow.Should().Be(attrs.MosaicType == "multi_row");
+            row.ElevationTierCount.Should().Be(attrs.ElevationRows);
+            row.MarsTimeStart.Should().Be(attrs.MarsTimeStart);
+            row.MarsTimeEnd.Should().Be(attrs.MarsTimeEnd);
+            row.Site.Should().Be(attrs.Location!.Site);
+            row.Drive.Should().Be(attrs.Location!.Drive);
+        }
+    }
+
+    [Fact]
+    public async Task Rebuild_IsIdempotent()
+    {
+        var first = await _builder.RebuildSolAsync(RoverId, Sol);
+        var firstRows = DbContext.Panoramas.AsEnumerable()
+            .Where(p => p.Sol == Sol)
+            .OrderBy(p => p.SequenceIndex)
+            .Select(p => (p.PanoramaId, p.TotalPhotos, p.CoverageDegrees))
+            .ToList();
+
+        var second = await _builder.RebuildSolAsync(RoverId, Sol);
+        var secondRows = DbContext.Panoramas.AsEnumerable()
+            .Where(p => p.Sol == Sol)
+            .OrderBy(p => p.SequenceIndex)
+            .Select(p => (p.PanoramaId, p.TotalPhotos, p.CoverageDegrees))
+            .ToList();
+
+        second.Should().Be(first, "rebuilding an unchanged sol writes the same number of rows");
+        secondRows.Should().Equal(firstRows, "the rows are identical across rebuilds");
+    }
+
+    [Fact]
+    public async Task Rebuild_DroppingStitchedReferencedId_DoesNotThrow()
+    {
+        await _builder.RebuildSolAsync(RoverId, Sol);
+        // Point a stitched_panoramas row at a panorama id that will not exist
+        // after we remove the photos and rebuild.
+        var existingId = DbContext.Panoramas.AsEnumerable().First(p => p.Sol == Sol).PanoramaId;
+        DbContext.StitchedPanoramas.Add(new StitchedPanorama
+        {
+            PanoramaId = existingId,
+            Status = "completed",
+            CreatedAt = DateTime.UtcNow,
+        });
+        DbContext.Photos.RemoveRange(DbContext.Photos.Where(p => p.Sol == Sol));
+        await DbContext.SaveChangesAsync();
+
+        var rebuilt = await _builder.RebuildSolAsync(RoverId, Sol);
+
+        rebuilt.Should().Be(0, "with the photos gone there are no panoramas to detect");
+        DbContext.Panoramas.AsEnumerable().Any(p => p.Sol == Sol).Should().BeFalse();
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/PanoramaTableMigrationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/PanoramaTableMigrationTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Entities;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// Proves the panoramas table was created by the migration, round-trips the
+/// int[] photo_ids array, and enforces the two uniqueness constraints the
+/// pre-compute builder and stitch/rating resolution depend on.
+/// </summary>
+public class PanoramaTableMigrationTests : IntegrationTestBase
+{
+    private Panorama MakePanorama(string panoramaId, int sequenceIndex) => new()
+    {
+        PanoramaId = panoramaId,
+        RoverId = 1,
+        Sol = 1000,
+        SequenceIndex = sequenceIndex,
+        CameraId = 2,
+        MarsTimeStart = "12:00:00",
+        MarsTimeEnd = "12:04:00",
+        TotalPhotos = 12,
+        CoverageDegrees = 210f,
+        AvgElevation = -5f,
+        UniquePositions = 8,
+        AvgPositionSpacing = 26f,
+        QualityTier = "wide",
+        IsMultiRow = false,
+        ElevationTierCount = 1,
+        AzimuthColumnCount = 8,
+        PhotoIds = new[] { 10, 20, 30 },
+        DetectedAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task RoundTripsARow_IncludingPhotoIdsArray()
+    {
+        DbContext.Panoramas.Add(MakePanorama("pano_curiosity_1000_0", 0));
+        await DbContext.SaveChangesAsync();
+
+        var row = await DbContext.Panoramas.AsNoTracking()
+            .SingleAsync(p => p.PanoramaId == "pano_curiosity_1000_0");
+
+        row.PhotoIds.Should().Equal(10, 20, 30);
+        row.CoverageDegrees.Should().Be(210f);
+        row.QualityTier.Should().Be("wide");
+        row.Site.Should().BeNull("single-row panorama without location leaves site null");
+    }
+
+    [Fact]
+    public async Task RejectsDuplicatePanoramaId()
+    {
+        DbContext.Panoramas.Add(MakePanorama("pano_curiosity_1000_0", 0));
+        await DbContext.SaveChangesAsync();
+
+        // Same panorama_id, different sequence index -> panorama_id unique index must reject.
+        DbContext.Panoramas.Add(MakePanorama("pano_curiosity_1000_0", 1));
+        var act = async () => await DbContext.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task RejectsDuplicateRoverSolSequenceIndex()
+    {
+        DbContext.Panoramas.Add(MakePanorama("pano_curiosity_1000_0", 0));
+        await DbContext.SaveChangesAsync();
+
+        // Different panorama_id but same (rover, sol, sequence index) -> canonical
+        // identity unique index must reject.
+        DbContext.Panoramas.Add(MakePanorama("pano_curiosity_1000_0_dup", 0));
+        var act = async () => await DbContext.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/V2/PanoramasIntegrationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PanoramasIntegrationTests.cs
@@ -14,6 +14,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     protected override void ConfigureServices(IServiceCollection services)
     {
         services.AddScoped<IPhotoQueryServiceV2, PhotoQueryServiceV2>();
+        services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
         services.AddScoped<IPanoramaService, PanoramaService>();
     }
 

--- a/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
+++ b/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
@@ -21,6 +21,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
 
         services.AddSingleton(_mockLogger.Object);
         services.AddSingleton(_mockPhotoService.Object);
+        services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
         services.AddScoped<PanoramaService>();
     }
 

--- a/tests/MarsVista.Api.Tests/Services/V2/PanoramaServiceTests.cs
+++ b/tests/MarsVista.Api.Tests/Services/V2/PanoramaServiceTests.cs
@@ -22,6 +22,7 @@ public class PanoramaServiceTests : IntegrationTestBase
 
         services.AddSingleton(_mockLogger.Object);
         services.AddSingleton(_mockPhotoService.Object);
+        services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
         services.AddScoped<PanoramaService>();
     }
 


### PR DESCRIPTION
## Summary

Foundation for moving `/api/v2/panoramas` off request-time detection (currently 6-9 s per request via a per-sol N+1 loop over the photos table, ~50 req/day) and onto a pre-computed table. **This PR lands the table empty and changes no read path** — the cutover is a separate PR gated on a production orphan check.

Four commits:

1. **Extract detection to Core** (`PanoramaDetector`) — pure move of the detection algorithm (grouping, time-contiguous blocks, elevation-tier clustering, mosaic/single-row validation, quality tiering) out of the API's `PanoramaService` so the scraper can share it. All 65 existing panorama tests pass unmodified.
2. **`panoramas` table** (entity + EF migration) — materializes the presentation values `ToPanoramaResource` computes (coverage, quality tier, mosaic geometry, normalized mars times, location, `photo_ids int[]`). Canonical identity `(rover_id, sol, sequence_index)` unique; `panorama_id` separately unique because the stitch service and ratings resolve against it.
3. **`PanoramaTableBuilder`** — per-(rover, sol) idempotent transactional rebuild. Orders candidate photos exactly as the request-time detail path so sequence indices — and therefore panorama ids — match what stitched images and ratings already reference. Warns (does not throw) when a rebuild drops a stitched-referenced id. A parity test asserts builder rows equal live detection output field-for-field.
4. **Backfill mode** (`PanoramaBackfillRunner` + scraper `PANORAMA_BACKFILL=true`) — enumerates every (rover, sol) with candidate photos and rebuilds each; per-sol error isolation; resumable by re-running.

## Testing

- Detection move: 65 existing panorama tests green, unmodified.
- New: table round-trip + both uniqueness constraints; builder parity vs live detection + idempotency + orphan-warning; backfill enumeration + rover filter.
- Full suite: 454 tests green.

## Deploy sequence (after merge)

1. Merge → `panoramas` table deploys **empty**; zero user-facing change (no read path uses it).
2. Run the one-off backfill: Railway job of the scraper image with `PANORAMA_BACKFILL=true`.
3. **Zero-orphan go/no-go gate** before any cutover:
   ```sql
   SELECT sp.panorama_id FROM stitched_panoramas sp
   LEFT JOIN panoramas p ON p.panorama_id = sp.panorama_id WHERE p.id IS NULL;   -- must be 0
   -- same against panorama_ratings
   ```
4. Only if the gate is clean: the read-path cutover PR (rewrites `GetPanoramasAsync`/`GetPanoramaByIdAsync` to read the table, adds the scraper's daily incremental refresh).

## Notes

- **EF migration ordering with #22 (retention):** both add a migration and touch `MarsVistaDbContextModelSnapshot.cs`. They edit different, alphabetically-distant entities so git should auto-merge; whichever merges second may need a trivial snapshot check. Neither depends on the other.
- Adds Core entities → bump the Core submodule in mars-vista-ops after merge.