### PR TITLE
Fix panorama builder transaction under retry strategy + backfill progress/ETA

### DIFF
--- a/src/MarsVista.Core/Services/PanoramaBackfillRunner.cs
+++ b/src/MarsVista.Core/Services/PanoramaBackfillRunner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using MarsVista.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,10 @@ public record PanoramaBackfillSummary(int TotalPairs, int Processed, int Panoram
 /// </summary>
 public class PanoramaBackfillRunner
 {
+    // Log a progress line (with rate + ETA) every this many sols. ~4,400 sols
+    // total, so this yields a progress update roughly every 20-30 seconds.
+    private const int ProgressLogInterval = 50;
+
     private readonly MarsVistaDbContext _context;
     private readonly IPanoramaTableBuilder _builder;
     private readonly ILogger<PanoramaBackfillRunner> _logger;
@@ -60,6 +65,7 @@ public class PanoramaBackfillRunner
         var processed = 0;
         var panoramas = 0;
         var failures = 0;
+        var stopwatch = Stopwatch.StartNew();
 
         foreach (var pair in pairs)
         {
@@ -68,11 +74,17 @@ public class PanoramaBackfillRunner
                 panoramas += await _builder.RebuildSolAsync(pair.RoverId, pair.Sol, cancellationToken);
                 processed++;
 
-                if (processed % 100 == 0)
+                if (processed % ProgressLogInterval == 0 || processed == pairs.Count)
                 {
+                    var elapsed = stopwatch.Elapsed;
+                    var solsPerSecond = processed / elapsed.TotalSeconds;
+                    var remaining = pairs.Count - processed;
+                    var etaMinutes = solsPerSecond > 0 ? remaining / solsPerSecond / 60.0 : 0;
+
                     _logger.LogInformation(
-                        "Backfill progress: {Processed}/{Total} sols, {Panoramas} panoramas written",
-                        processed, pairs.Count, panoramas);
+                        "Backfill progress: {Processed}/{Total} sols ({Percent:F0}%), {Panoramas} panoramas, {Rate:F1} sols/s, elapsed {ElapsedMin:F1}m, ETA {EtaMin:F1}m",
+                        processed, pairs.Count, 100.0 * processed / pairs.Count, panoramas,
+                        solsPerSecond, elapsed.TotalMinutes, etaMinutes);
                 }
             }
             catch (Exception ex)
@@ -84,9 +96,10 @@ public class PanoramaBackfillRunner
             }
         }
 
+        stopwatch.Stop();
         _logger.LogInformation(
-            "Panorama backfill complete: {Processed}/{Total} sols processed, {Panoramas} panoramas written, {Failures} failures",
-            processed, pairs.Count, panoramas, failures);
+            "Panorama backfill complete: {Processed}/{Total} sols processed, {Panoramas} panoramas written, {Failures} failures in {ElapsedMin:F1}m",
+            processed, pairs.Count, panoramas, failures, stopwatch.Elapsed.TotalMinutes);
 
         return new PanoramaBackfillSummary(pairs.Count, processed, panoramas, failures);
     }

--- a/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
+++ b/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
@@ -69,20 +69,31 @@ public class PanoramaTableBuilder : IPanoramaTableBuilder
         await WarnOnOrphanedStitchesAsync(roverId, sol, rows, cancellationToken);
 
         // Idempotent replace: drop the sol's existing rows and insert the fresh
-        // set atomically so a reader never sees a half-rebuilt sol.
-        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
-
-        await _context.Panoramas
-            .Where(p => p.RoverId == roverId && p.Sol == sol)
-            .ExecuteDeleteAsync(cancellationToken);
-
-        if (rows.Count > 0)
+        // set atomically so a reader never sees a half-rebuilt sol. The whole
+        // unit runs inside an execution strategy because the API/scraper
+        // DbContext enables retry-on-failure, which forbids a bare
+        // BeginTransactionAsync - the strategy re-runs the lambda on a transient
+        // failure, so the change tracker is cleared each attempt to keep retries
+        // clean.
+        var strategy = _context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
-            _context.Panoramas.AddRange(rows);
-            await _context.SaveChangesAsync(cancellationToken);
-        }
+            _context.ChangeTracker.Clear();
 
-        await transaction.CommitAsync(cancellationToken);
+            await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            await _context.Panoramas
+                .Where(p => p.RoverId == roverId && p.Sol == sol)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            if (rows.Count > 0)
+            {
+                _context.Panoramas.AddRange(rows);
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        });
 
         _logger.LogDebug("Rebuilt {Count} panoramas for rover {RoverId} sol {Sol}", rows.Count, roverId, sol);
         return rows.Count;

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -15,6 +15,9 @@ using Serilog.Formatting.Compact;
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Information()
+    // Silence EF Core's per-command logging (matches the API config) so scrape
+    // and backfill progress is not buried under a flood of SQL command logs.
+    .MinimumLevel.Override("Microsoft.EntityFrameworkCore", Serilog.Events.LogEventLevel.Warning)
     .Enrich.FromLogContext()
     .WriteTo.Console(new CompactJsonFormatter())
     .CreateLogger();

--- a/tests/MarsVista.Api.Tests/Integration/IntegrationTestBase.cs
+++ b/tests/MarsVista.Api.Tests/Integration/IntegrationTestBase.cs
@@ -121,7 +121,12 @@ public abstract class IntegrationTestBase : IAsyncLifetime
 
         services.AddDbContext<MarsVistaDbContext>(options =>
         {
-            options.UseNpgsql(_connectionString)
+            // Enable retry-on-failure to match the API and scraper DbContext config.
+            // Under a retrying execution strategy EF forbids user-initiated
+            // transactions, so any service that opens one must go through
+            // Database.CreateExecutionStrategy() - keeping this here means the
+            // integration tests exercise the same constraint production does.
+            options.UseNpgsql(_connectionString, npgsql => npgsql.EnableRetryOnFailure())
                 .UseSnakeCaseNamingConvention()
                 .AddInterceptors(SqlCapture)
                 .ConfigureWarnings(warnings =>


### PR DESCRIPTION
## Summary

Running the panorama backfill against the real scraper configuration surfaced a bug the tests missed: **`PanoramaTableBuilder` opened a bare `BeginTransactionAsync`, which EF Core forbids when the DbContext enables `EnableRetryOnFailure`** — as both the API (`Program.cs:99`) and scraper (`Program.cs:53`) do. Every `RebuildSolAsync` threw *"the configured execution strategy does not support user-initiated transactions"*, so the first backfill run wrote **zero** rows.

The builder's tests passed only because `IntegrationTestBase` didn't enable retry-on-failure — a test-vs-production config gap.

### Fixes

1. **Builder** — wrap the delete-and-insert in `Database.CreateExecutionStrategy().ExecuteAsync(...)`, clearing the change tracker at the start of each attempt so a retry after a transient failure re-runs cleanly.
2. **Test base** — enable `EnableRetryOnFailure()` to match the API/scraper config. This reproduces the failure on the pre-fix builder (RED) and guards every future service that opens a transaction.
3. **Backfill observability** — progress line every 50 sols with percent, throughput, elapsed, and ETA; total elapsed in the completion summary; EF per-command logging silenced in the scraper (matching the API) so progress isn't buried.

## Testing

- The retry-enabled test base reproduces the exact production exception on the pre-fix builder; the execution-strategy fix makes it pass.
- Full suite: **469 tests green** (163 scraper + 306 API).

## Validation

Verified end-to-end by running the fixed backfill against production: Perseverance wrote 66 panoramas across 276 sols with **0 failures** (the pre-fix build failed all of them).

## Notes

- This bug is currently **dormant on `main`**: the deployed builder is only invoked by the backfill mode (a one-off job) and the not-yet-added incremental refresh (Phase 5.3). It must land before Phase 5.3.
- No migration; no ops submodule change needed.