### PR TITLE
Panorama read-path cutover: serve /api/v2/panoramas from the pre-computed table

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -214,7 +214,7 @@
           {
             "name": "min_photos",
             "in": "query",
-            "description": "Minimum number of photos in panorama",
+            "description": "Only return panoramas with at least this many photos",
             "schema": {
               "type": "integer",
               "format": "int32"

--- a/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
+++ b/src/MarsVista.Api/Controllers/V2/PanoramasController.cs
@@ -42,7 +42,7 @@ public class PanoramasController : ControllerBase
     /// <param name="rovers">Comma-separated list of rover names (curiosity, perseverance, etc.)</param>
     /// <param name="sol_min">Minimum sol</param>
     /// <param name="sol_max">Maximum sol</param>
-    /// <param name="min_photos">Minimum number of photos in panorama</param>
+    /// <param name="min_photos">Only return panoramas with at least this many photos</param>
     /// <param name="stitch_status">Filter by stitch status: completed, failed, processing, not_started</param>
     /// <param name="stitch_method">Filter by stitch method: feature_match, telemetry_projection</param>
     /// <param name="mosaic_type">Filter by mosaic type: single_row, multi_row</param>

--- a/src/MarsVista.Api/Program.cs
+++ b/src/MarsVista.Api/Program.cs
@@ -197,7 +197,6 @@ builder.Services.AddHostedService<MarsVista.Api.Services.V2.CacheWarmingBackgrou
 builder.Services.AddHostedService<MarsVista.Api.Services.V2.CacheStatsLoggingService>();
 
 // v2 Phase 2 advanced features services
-builder.Services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IPanoramaService, MarsVista.Api.Services.V2.PanoramaService>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.ILocationService, MarsVista.Api.Services.V2.LocationService>();
 builder.Services.AddScoped<MarsVista.Api.Services.V2.IJourneyService, MarsVista.Api.Services.V2.JourneyService>();

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -2,14 +2,16 @@ using Microsoft.EntityFrameworkCore;
 using MarsVista.Core.Data;
 using MarsVista.Core.Entities;
 using MarsVista.Core.Services;
+using MarsVista.Api.Services;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Core.Helpers;
 
 namespace MarsVista.Api.Services.V2;
 
 /// <summary>
-/// Implementation of panorama detection service
-/// Detects panoramic sequences based on location, time, and camera telemetry
+/// Reads pre-computed panoramas from the panoramas table (populated by the
+/// scraper via PanoramaTableBuilder) and maps them to API resources. Filtering,
+/// sorting, and pagination all happen at the database level.
 /// </summary>
 public class PanoramaService : IPanoramaService
 {
@@ -17,21 +19,24 @@ public class PanoramaService : IPanoramaService
     private readonly ILogger<PanoramaService> _logger;
     private readonly IPhotoQueryServiceV2 _photoService;
     private readonly PanoramaDetector _detector;
+    private readonly IStaticReferenceCache _referenceCache;
 
-    // Performance optimization: Limit sol range to prevent loading all photos into memory
-    // TODO: Long-term solution should pre-compute panoramas in a dedicated table (see .claude/decisions/PANORAMA_OPTIMIZATION.md)
-    private const int DefaultSolRangeLimit = 500; // Default to most recent 500 sols when no range specified
+    // When no sol range is given, default to the most recent N sols per the
+    // rover-filtered result, matching the previous detection-path default.
+    private const int DefaultSolRangeLimit = 500;
 
     public PanoramaService(
         MarsVistaDbContext context,
         ILogger<PanoramaService> logger,
         IPhotoQueryServiceV2 photoService,
-        PanoramaDetector detector)
+        PanoramaDetector detector,
+        IStaticReferenceCache referenceCache)
     {
         _context = context;
         _logger = logger;
         _photoService = photoService;
         _detector = detector;
+        _referenceCache = referenceCache;
     }
 
     public async Task<ApiResponse<List<PanoramaResource>>> GetPanoramasAsync(
@@ -50,43 +55,37 @@ public class PanoramaService : IPanoramaService
         int pageSize = 25,
         CancellationToken cancellationToken = default)
     {
-        // Build query for photos that could be part of panoramas
-        // Only include cameras designed for panoramic imaging
-        var query = _context.Photos
-            .Where(p => p.Site.HasValue &&
-                       p.Drive.HasValue &&
-                       p.MastAz.HasValue &&
-                       p.MastEl.HasValue &&
-                       p.SpacecraftClock.HasValue &&
-                       PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name));
+        // Query the pre-computed panoramas table; all filtering, sorting, and
+        // pagination happen in the database.
+        var query = _context.Panoramas.AsNoTracking();
 
-        // Apply filters
+        // Rover filter via the static reference cache (rover_id, not a name join -
+        // see story 052a). Unknown rover names resolve to nothing -> empty result.
         if (!string.IsNullOrWhiteSpace(rovers))
         {
-            var roverList = rovers.Split(',')
+            var roverIds = rovers.Split(',')
                 .Select(r => r.Trim())
                 .Where(r => !string.IsNullOrWhiteSpace(r))
+                .Select(r => _referenceCache.GetRoverIdByName(r))
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .Distinct()
                 .ToList();
 
-            // Use case-insensitive comparison via ILIKE (PostgreSQL)
-            // EF Core will auto-join to Rover table for this filter
-            query = query.Where(p => roverList.Any(r => EF.Functions.ILike(p.Rover.Name, r)));
+            if (roverIds.Count == 0)
+            {
+                return EmptyResponse(pageNumber, pageSize);
+            }
+
+            query = roverIds.Count == 1
+                ? query.Where(p => p.RoverId == roverIds[0])
+                : query.Where(p => roverIds.Contains(p.RoverId));
         }
 
-        if (solMin.HasValue)
-        {
-            query = query.Where(p => p.Sol >= solMin.Value);
-            _logger.LogDebug("Applied solMin filter: {SolMin}", solMin.Value);
-        }
+        if (solMin.HasValue) query = query.Where(p => p.Sol >= solMin.Value);
+        if (solMax.HasValue) query = query.Where(p => p.Sol <= solMax.Value);
 
-        if (solMax.HasValue)
-        {
-            query = query.Where(p => p.Sol <= solMax.Value);
-            _logger.LogDebug("Applied solMax filter: {SolMax}", solMax.Value);
-        }
-
-        // Performance optimization: If no sol range specified, default to recent sols
-        // This prevents loading 200k+ photos into memory (which takes 2-3 minutes)
+        // No sol range -> default to the most recent N sols of the filtered set.
         if (!solMin.HasValue && !solMax.HasValue)
         {
             var maxSol = await query.MaxAsync(p => (int?)p.Sol, cancellationToken);
@@ -94,174 +93,101 @@ public class PanoramaService : IPanoramaService
             {
                 var defaultSolMin = Math.Max(0, maxSol.Value - DefaultSolRangeLimit);
                 query = query.Where(p => p.Sol >= defaultSolMin);
-
-                _logger.LogDebug(
-                    "No sol range specified, defaulting to recent {SolCount} sols (sol {MinSol} to {MaxSol})",
-                    DefaultSolRangeLimit, defaultSolMin, maxSol.Value);
             }
         }
 
-        // OPTIMIZATION: Process panoramas in batches by sol to avoid loading all photos into memory
-        // Get distinct sols that have potential panorama photos
-        var sols = await query
-            .Select(p => p.Sol)
-            .Distinct()
-            .OrderBy(s => s)
-            .ToListAsync(cancellationToken);
-
-        _logger.LogDebug("Found {SolCount} distinct sols to process. First 5: [{Sols}]",
-            sols.Count,
-            string.Join(", ", sols.Take(5)));
-
-        var allPanoramas = new List<PanoramaSequence>();
-
-        // Process each sol independently to limit memory usage
-        foreach (var sol in sols)
-        {
-            // Order by time, then by elevation to group photos at similar angles together
-            // This prevents non-deterministic ordering when photos have the same spacecraft_clock
-            // (bracketed exposures or multi-camera captures at the same instant)
-            var solPhotos = await query
-                .Where(p => p.Sol == sol)
-                .Include(p => p.Rover)
-                .Include(p => p.Camera)
-                .AsNoTracking() // Don't track entities for read-only operations
-                .OrderBy(p => p.RoverId)
-                .ThenBy(p => p.Site)
-                .ThenBy(p => p.Drive)
-                .ThenBy(p => p.SpacecraftClock)
-                .ThenBy(p => p.MastEl) // Group photos at similar elevations when same clock
-                .ToListAsync(cancellationToken);
-
-            // Detect panoramas for this sol - index resets per sol for stable IDs
-            var panoramaIndex = 0;
-            var solPanoramas = _detector.DetectPanoramasOptimized(solPhotos, minPhotos ?? PanoramaDetector.MinPhotosForPanorama, ref panoramaIndex);
-
-            if (sols.Count <= 5 || solPanoramas.Count > 0)
-            {
-                _logger.LogDebug("Sol {Sol}: {PhotoCount} photos, {PanoramaCount} panoramas detected",
-                    sol, solPhotos.Count, solPanoramas.Count);
-            }
-
-            allPanoramas.AddRange(solPanoramas);
-        }
-
-        // Apply in-memory filters on detected panoramas
-        var filtered = (IEnumerable<PanoramaSequence>)allPanoramas;
+        // min_photos is now a filter over the stored panoramas (total_photos >= N),
+        // not a re-detection - so the panorama set and its ids are stable.
+        if (minPhotos.HasValue) query = query.Where(p => p.TotalPhotos >= minPhotos.Value);
 
         if (!string.IsNullOrWhiteSpace(mosaicType))
         {
-            var isMr = mosaicType.Equals("multi_row", StringComparison.OrdinalIgnoreCase);
-            filtered = filtered.Where(p => p.IsMultiRow == isMr);
+            var isMultiRow = mosaicType.Equals("multi_row", StringComparison.OrdinalIgnoreCase);
+            query = query.Where(p => p.IsMultiRow == isMultiRow);
         }
 
         if (!string.IsNullOrWhiteSpace(quality))
         {
-            filtered = filtered.Where(p =>
-            {
-                var azimuths = p.Photos.Select(ph => ph.MastAz ?? 0);
-                var coverage = azimuths.Max() - azimuths.Min();
-                var positions = p.Photos.Select(ph => Math.Round(ph.MastAz ?? 0)).Distinct().Count();
-                return PanoramaDetector.GetQualityTier(coverage, positions).Equals(quality, StringComparison.OrdinalIgnoreCase);
-            });
+            var qualityTier = quality.ToLowerInvariant();
+            query = query.Where(p => p.QualityTier == qualityTier);
         }
 
-        var panoramas = filtered.ToList();
-
-        // Build panorama IDs for all remaining panoramas (needed for stitch/rating filters)
-        var allPanoramaIds = panoramas.Select(p => GetPanoramaId(p)).ToList();
-
-        // Load stitch statuses and ratings for filtering
-        var allStitchStatuses = allPanoramaIds.Count > 0
-            ? await _context.StitchedPanoramas
-                .AsNoTracking()
-                .Where(s => allPanoramaIds.Contains(s.PanoramaId))
-                .ToDictionaryAsync(s => s.PanoramaId, cancellationToken)
-            : new Dictionary<string, StitchedPanorama>();
-
-        var allRatingAggregates = allPanoramaIds.Count > 0
-            ? await _context.PanoramaRatings
-                .AsNoTracking()
-                .Where(r => allPanoramaIds.Contains(r.PanoramaId))
-                .GroupBy(r => r.PanoramaId)
-                .Select(g => new { PanoramaId = g.Key, Avg = g.Average(r => r.Rating), Count = g.Count() })
-                .ToDictionaryAsync(
-                    r => r.PanoramaId,
-                    r => new RatingAggregate(r.Avg, r.Count),
-                    cancellationToken)
-            : new Dictionary<string, RatingAggregate>();
-
-        // Apply stitch/rating filters
+        // Stitch status/method filters via the stitched_panoramas table
         if (!string.IsNullOrWhiteSpace(stitchStatus))
         {
-            panoramas = panoramas.Where(p =>
+            if (stitchStatus.Equals("not_started", StringComparison.OrdinalIgnoreCase))
             {
-                var pid = GetPanoramaId(p);
-                if (stitchStatus.Equals("not_started", StringComparison.OrdinalIgnoreCase))
-                    return !allStitchStatuses.ContainsKey(pid);
-                return allStitchStatuses.TryGetValue(pid, out var s) &&
-                       s.Status.Equals(stitchStatus, StringComparison.OrdinalIgnoreCase);
-            }).ToList();
+                query = query.Where(p => !_context.StitchedPanoramas.Any(s => s.PanoramaId == p.PanoramaId));
+            }
+            else
+            {
+                var status = stitchStatus.ToLowerInvariant();
+                query = query.Where(p => _context.StitchedPanoramas.Any(s => s.PanoramaId == p.PanoramaId && s.Status == status));
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(stitchMethod))
         {
-            panoramas = panoramas.Where(p =>
-            {
-                var pid = GetPanoramaId(p);
-                return allStitchStatuses.TryGetValue(pid, out var s) &&
-                       s.StitchMethod != null &&
-                       s.StitchMethod.Equals(stitchMethod, StringComparison.OrdinalIgnoreCase);
-            }).ToList();
+            var method = stitchMethod.ToLowerInvariant();
+            query = query.Where(p => _context.StitchedPanoramas.Any(s => s.PanoramaId == p.PanoramaId && s.StitchMethod == method));
         }
 
+        // min_rating filter via a pre-aggregated (non-correlated) subquery on ratings
         if (minRating.HasValue)
         {
-            panoramas = panoramas.Where(p =>
-            {
-                var pid = GetPanoramaId(p);
-                return allRatingAggregates.TryGetValue(pid, out var r) && r.Average >= minRating.Value;
-            }).ToList();
+            var qualifyingIds = _context.PanoramaRatings
+                .GroupBy(r => r.PanoramaId)
+                .Where(g => g.Average(r => r.Rating) >= minRating.Value)
+                .Select(g => g.Key);
+            query = query.Where(p => qualifyingIds.Contains(p.PanoramaId));
         }
 
-        // Apply sorting
+        // Sorting
         var sortField = sort?.ToLowerInvariant() ?? "sol";
         var isAscending = order?.Equals("asc", StringComparison.OrdinalIgnoreCase) == true;
 
-        panoramas = sortField switch
+        query = sortField switch
         {
-            "rating" => isAscending
-                ? panoramas.OrderBy(p => allRatingAggregates.TryGetValue(GetPanoramaId(p), out var r) ? r.Average : 0).ToList()
-                : panoramas.OrderByDescending(p => allRatingAggregates.TryGetValue(GetPanoramaId(p), out var r) ? r.Average : 0).ToList(),
             "coverage" => isAscending
-                ? panoramas.OrderBy(p => p.Photos.Select(ph => ph.MastAz ?? 0).Max() - p.Photos.Select(ph => ph.MastAz ?? 0).Min()).ToList()
-                : panoramas.OrderByDescending(p => p.Photos.Select(ph => ph.MastAz ?? 0).Max() - p.Photos.Select(ph => ph.MastAz ?? 0).Min()).ToList(),
+                ? query.OrderBy(p => p.CoverageDegrees)
+                : query.OrderByDescending(p => p.CoverageDegrees),
             "photos" => isAscending
-                ? panoramas.OrderBy(p => p.Photos.Count).ToList()
-                : panoramas.OrderByDescending(p => p.Photos.Count).ToList(),
-            _ => panoramas // Default: sol order (already in sol order from detection)
+                ? query.OrderBy(p => p.TotalPhotos)
+                : query.OrderByDescending(p => p.TotalPhotos),
+            "rating" => isAscending
+                ? query.OrderBy(p => _context.PanoramaRatings.Where(r => r.PanoramaId == p.PanoramaId).Average(r => (double?)r.Rating) ?? 0.0)
+                : query.OrderByDescending(p => _context.PanoramaRatings.Where(r => r.PanoramaId == p.PanoramaId).Average(r => (double?)r.Rating) ?? 0.0),
+            // Default: canonical order (sol, then rover-scoped sequence index)
+            _ => query.OrderBy(p => p.Sol).ThenBy(p => p.RoverId).ThenBy(p => p.SequenceIndex)
         };
 
-        // Apply pagination
-        var totalCount = panoramas.Count;
-        var paginatedPanoramas = panoramas
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var pageEntities = await query
+            .Include(p => p.Rover)
+            .Include(p => p.Camera)
             .Skip((pageNumber - 1) * pageSize)
             .Take(pageSize)
-            .ToList();
+            .ToListAsync(cancellationToken);
 
-        // Build stitch/rating dictionaries for just the paginated results
-        var paginatedIds = new HashSet<string>(paginatedPanoramas.Select(p => GetPanoramaId(p)));
+        // Decorate the page with stitch status and rating aggregates
+        var pageIds = pageEntities.Select(p => p.PanoramaId).ToList();
 
-        var stitchStatuses = allStitchStatuses
-            .Where(kv => paginatedIds.Contains(kv.Key))
-            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        var stitchMap = pageIds.Count > 0
+            ? await _context.StitchedPanoramas.AsNoTracking()
+                .Where(s => pageIds.Contains(s.PanoramaId))
+                .ToDictionaryAsync(s => s.PanoramaId, cancellationToken)
+            : new Dictionary<string, StitchedPanorama>();
 
-        var ratingAggregates = allRatingAggregates
-            .Where(kv => paginatedIds.Contains(kv.Key))
-            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        var ratingMap = pageIds.Count > 0
+            ? await _context.PanoramaRatings.AsNoTracking()
+                .Where(r => pageIds.Contains(r.PanoramaId))
+                .GroupBy(r => r.PanoramaId)
+                .Select(g => new { PanoramaId = g.Key, Avg = g.Average(r => r.Rating), Count = g.Count() })
+                .ToDictionaryAsync(x => x.PanoramaId, x => new RatingAggregate(x.Avg, x.Count), cancellationToken)
+            : new Dictionary<string, RatingAggregate>();
 
-        // Convert to resources
-        var resources = paginatedPanoramas.Select(p => ToPanoramaResource(p, stitchStatuses, ratingAggregates: ratingAggregates)).ToList();
+        var resources = pageEntities.Select(p => MapEntityToResource(p, stitchMap, ratingMap)).ToList();
 
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
 
@@ -280,6 +206,13 @@ public class PanoramaService : IPanoramaService
             }
         };
     }
+
+    private static ApiResponse<List<PanoramaResource>> EmptyResponse(int pageNumber, int pageSize) =>
+        new(new List<PanoramaResource>())
+        {
+            Meta = new ResponseMeta { TotalCount = 0, ReturnedCount = 0 },
+            Pagination = new PaginationInfo { Page = pageNumber, PerPage = pageSize, TotalPages = 0 }
+        };
 
     public async Task<PanoramaResource?> GetPanoramaByIdAsync(
         string panoramaId,
@@ -424,6 +357,94 @@ public class PanoramaService : IPanoramaService
             return null;
 
         return panoramas[sequenceIndex];
+    }
+
+    /// <summary>
+    /// Map a stored panorama entity to a resource DTO. The entity already holds
+    /// the presentation values (coverage, quality, mosaic geometry, normalized
+    /// mars times, location), so no per-photo computation is needed.
+    /// </summary>
+    private static PanoramaResource MapEntityToResource(
+        Panorama p,
+        IReadOnlyDictionary<string, StitchedPanorama> stitchMap,
+        IReadOnlyDictionary<string, RatingAggregate> ratingMap,
+        List<PhotoResource>? photoResources = null)
+    {
+        stitchMap.TryGetValue(p.PanoramaId, out var stitchRecord);
+        ratingMap.TryGetValue(p.PanoramaId, out var ratingAgg);
+
+        PhotoLocation? location = null;
+        if (p.Site.HasValue && p.Drive.HasValue)
+        {
+            PhotoCoordinates? coordinates = null;
+            if (p.CoordinateX.HasValue && p.CoordinateY.HasValue && p.CoordinateZ.HasValue)
+            {
+                coordinates = new PhotoCoordinates
+                {
+                    X = p.CoordinateX.Value,
+                    Y = p.CoordinateY.Value,
+                    Z = p.CoordinateZ.Value
+                };
+            }
+
+            location = new PhotoLocation
+            {
+                Site = p.Site,
+                Drive = p.Drive,
+                Coordinates = coordinates
+            };
+        }
+
+        var stitchInfo = new StitchInfo
+        {
+            Status = stitchRecord?.Status ?? "not_started",
+            Method = stitchRecord?.StitchMethod,
+            Width = stitchRecord?.Status == "completed" ? stitchRecord.ImageWidth : null,
+            Height = stitchRecord?.Status == "completed" ? stitchRecord.ImageHeight : null,
+            AverageRating = ratingAgg != null ? Math.Round(ratingAgg.Average, 1) : null,
+            RatingCount = ratingAgg?.Count
+        };
+
+        return new PanoramaResource
+        {
+            Id = p.PanoramaId,
+            Type = "panorama",
+            Photos = photoResources,
+            Attributes = new PanoramaAttributes
+            {
+                Rover = p.Rover.Name.ToLowerInvariant(),
+                Sol = p.Sol,
+                MarsTimeStart = p.MarsTimeStart,
+                MarsTimeEnd = p.MarsTimeEnd,
+                TotalPhotos = p.TotalPhotos,
+                CoverageDegrees = p.CoverageDegrees,
+                Location = location,
+                Camera = p.Camera.Name,
+                AvgElevation = p.AvgElevation,
+                UniquePositions = p.UniquePositions,
+                AvgPositionSpacing = p.AvgPositionSpacing,
+                Quality = p.QualityTier,
+                MosaicType = p.IsMultiRow ? "multi_row" : "single_row",
+                ElevationRows = p.ElevationTierCount,
+                ElevationRangeData = p.IsMultiRow
+                    ? new ElevationRange { Min = p.MinElevation ?? 0, Max = p.MaxElevation ?? 0 }
+                    : null,
+                GridDimensions = p.IsMultiRow
+                    ? $"{p.ElevationTierCount}x{p.AzimuthColumnCount}"
+                    : null,
+                VerticalCoverageDegrees = p.IsMultiRow
+                    ? (p.MaxElevation - p.MinElevation)
+                    : null,
+                Stitch = stitchInfo
+            },
+            Links = new PanoramaLinks
+            {
+                StitchedPreview = stitchRecord?.Status == "completed"
+                    ? $"/stitch/{p.PanoramaId}/image"
+                    : null,
+                DownloadSet = $"/api/v2/panoramas/{p.PanoramaId}/download"
+            }
+        };
     }
 
     /// <summary>

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using MarsVista.Core.Data;
 using MarsVista.Core.Entities;
-using MarsVista.Core.Services;
 using MarsVista.Api.Services;
 using MarsVista.Api.DTOs.V2;
 using MarsVista.Core.Helpers;
@@ -18,7 +17,6 @@ public class PanoramaService : IPanoramaService
     private readonly MarsVistaDbContext _context;
     private readonly ILogger<PanoramaService> _logger;
     private readonly IPhotoQueryServiceV2 _photoService;
-    private readonly PanoramaDetector _detector;
     private readonly IStaticReferenceCache _referenceCache;
 
     // When no sol range is given, default to the most recent N sols per the
@@ -29,13 +27,11 @@ public class PanoramaService : IPanoramaService
         MarsVistaDbContext context,
         ILogger<PanoramaService> logger,
         IPhotoQueryServiceV2 photoService,
-        PanoramaDetector detector,
         IStaticReferenceCache referenceCache)
     {
         _context = context;
         _logger = logger;
         _photoService = photoService;
-        _detector = detector;
         _referenceCache = referenceCache;
     }
 
@@ -318,50 +314,6 @@ public class PanoramaService : IPanoramaService
         };
     }
 
-    private async Task<PanoramaSequence?> DetectPanoramaSequenceByIdAsync(
-        string panoramaId,
-        CancellationToken cancellationToken)
-    {
-        // Parse panorama ID (format: "pano_curiosity_1000_14")
-        var parts = panoramaId.Split('_');
-        if (parts.Length != 4 || parts[0] != "pano")
-            return null;
-
-        var rover = parts[1];
-        if (!int.TryParse(parts[2], out var sol))
-            return null;
-        if (!int.TryParse(parts[3], out var sequenceIndex))
-            return null;
-
-        // Get all panoramas for this rover and sol
-        var query = _context.Photos
-            .Where(p => p.Rover.Name.ToLower() == rover &&
-                       p.Sol == sol &&
-                       p.Site.HasValue &&
-                       p.Drive.HasValue &&
-                       p.MastAz.HasValue &&
-                       p.MastEl.HasValue &&
-                       p.SpacecraftClock.HasValue &&
-                       PanoramaDetector.PanoramicCameras.Contains(p.Camera.Name));
-
-        var photos = await query
-            .Include(p => p.Rover)
-            .Include(p => p.Camera)
-            .OrderBy(p => p.RoverId)
-            .ThenBy(p => p.Site)
-            .ThenBy(p => p.Drive)
-            .ThenBy(p => p.SpacecraftClock)
-            .ThenBy(p => p.MastEl) // Must match GetPanoramasAsync ordering for consistent IDs
-            .ToListAsync(cancellationToken);
-
-        var panoramas = _detector.DetectPanoramas(photos, PanoramaDetector.MinPhotosForPanorama);
-
-        if (sequenceIndex < 0 || sequenceIndex >= panoramas.Count)
-            return null;
-
-        return panoramas[sequenceIndex];
-    }
-
     /// <summary>
     /// Map a stored panorama entity to a resource DTO. The entity already holds
     /// the presentation values (coverage, quality, mosaic geometry, normalized
@@ -448,159 +400,6 @@ public class PanoramaService : IPanoramaService
                 DownloadSet = $"/api/v2/panoramas/{p.PanoramaId}/download"
             }
         };
-    }
-
-    /// <summary>
-    /// Convert panorama sequence to resource DTO
-    /// </summary>
-    private PanoramaResource ToPanoramaResource(PanoramaSequence sequence,
-        Dictionary<string, StitchedPanorama>? stitchStatuses = null,
-        List<PhotoResource>? photoResources = null,
-        Dictionary<string, RatingAggregate>? ratingAggregates = null)
-    {
-        var firstPhoto = sequence.Photos.First();
-        var lastPhoto = sequence.Photos.Last();
-        var rover = firstPhoto.Rover.Name.ToLowerInvariant();
-        var sol = firstPhoto.Sol;
-
-        // Generate panorama ID using sequence index
-        var panoramaId = $"pano_{rover}_{sol}_{sequence.Index}";
-
-        // Calculate coverage
-        var azimuths = sequence.Photos.Select(p => p.MastAz ?? 0).ToList();
-        var coverageDegrees = azimuths.Max() - azimuths.Min();
-
-        // Calculate unique positions (distinct camera angles, rounded to nearest degree)
-        var uniqueAzimuths = sequence.Photos
-            .Select(p => Math.Round(p.MastAz ?? 0))
-            .Distinct()
-            .OrderBy(a => a)
-            .ToList();
-        var uniquePositions = uniqueAzimuths.Count;
-
-        // Calculate average spacing between positions
-        float? avgPositionSpacing = null;
-        if (uniquePositions > 1)
-        {
-            var totalSpacing = 0.0;
-            for (int i = 1; i < uniqueAzimuths.Count; i++)
-            {
-                totalSpacing += uniqueAzimuths[i] - uniqueAzimuths[i - 1];
-            }
-            avgPositionSpacing = (float)(totalSpacing / (uniquePositions - 1));
-        }
-
-        // Calculate quality tier
-        var quality = PanoramaDetector.GetQualityTier(coverageDegrees, uniquePositions);
-
-        // Get Mars time range (normalize so start <= end for reverse-sweep panoramas)
-        string? marsTimeStart = null;
-        string? marsTimeEnd = null;
-        TimeSpan parsedStart = default, parsedEnd = default;
-        bool hasStart = !string.IsNullOrEmpty(firstPhoto.DateTakenMars) &&
-            MarsTimeHelper.TryExtractTimeFromTimestamp(firstPhoto.DateTakenMars, out parsedStart);
-        bool hasEnd = !string.IsNullOrEmpty(lastPhoto.DateTakenMars) &&
-            MarsTimeHelper.TryExtractTimeFromTimestamp(lastPhoto.DateTakenMars, out parsedEnd);
-        if (hasStart) marsTimeStart = MarsTimeHelper.FormatMarsTime(parsedStart);
-        if (hasEnd) marsTimeEnd = MarsTimeHelper.FormatMarsTime(parsedEnd);
-        if (hasStart && hasEnd && parsedStart > parsedEnd)
-        {
-            (marsTimeStart, marsTimeEnd) = (marsTimeEnd, marsTimeStart);
-        }
-
-        // Average elevation
-        var avgElevation = sequence.Photos.Average(p => p.MastEl ?? 0);
-
-        // Build location
-        PhotoLocation? location = null;
-        if (firstPhoto.Site.HasValue && firstPhoto.Drive.HasValue)
-        {
-            PhotoCoordinates? coordinates = null;
-            if (!string.IsNullOrEmpty(firstPhoto.Xyz) &&
-                MarsTimeHelper.TryParseXYZ(firstPhoto.Xyz, out var parsed))
-            {
-                coordinates = new PhotoCoordinates
-                {
-                    X = parsed.X,
-                    Y = parsed.Y,
-                    Z = parsed.Z
-                };
-            }
-
-            location = new PhotoLocation
-            {
-                Site = firstPhoto.Site,
-                Drive = firstPhoto.Drive,
-                Coordinates = coordinates
-            };
-        }
-
-        // Build StitchInfo from stitch status and rating aggregates
-        // Always include StitchInfo for consistent API responses (never null)
-        StitchedPanorama? stitchRecord = null;
-        stitchStatuses?.TryGetValue(panoramaId, out stitchRecord);
-        RatingAggregate? ratingAgg = null;
-        ratingAggregates?.TryGetValue(panoramaId, out ratingAgg);
-
-        var stitchInfo = new StitchInfo
-        {
-            Status = stitchRecord?.Status ?? "not_started",
-            Method = stitchRecord?.StitchMethod,
-            Width = stitchRecord?.Status == "completed" ? stitchRecord.ImageWidth : null,
-            Height = stitchRecord?.Status == "completed" ? stitchRecord.ImageHeight : null,
-            AverageRating = ratingAgg != null ? Math.Round(ratingAgg.Average, 1) : null,
-            RatingCount = ratingAgg?.Count
-        };
-
-        return new PanoramaResource
-        {
-            Id = panoramaId,
-            Type = "panorama",
-            Photos = photoResources,
-            Attributes = new PanoramaAttributes
-            {
-                Rover = rover,
-                Sol = sol,
-                MarsTimeStart = marsTimeStart,
-                MarsTimeEnd = marsTimeEnd,
-                TotalPhotos = sequence.Photos.Count,
-                CoverageDegrees = coverageDegrees,
-                Location = location,
-                Camera = firstPhoto.Camera.Name,
-                AvgElevation = avgElevation,
-                UniquePositions = uniquePositions,
-                AvgPositionSpacing = avgPositionSpacing,
-                Quality = quality,
-                MosaicType = sequence.IsMultiRow ? "multi_row" : "single_row",
-                ElevationRows = sequence.ElevationTierCount,
-                ElevationRangeData = sequence.IsMultiRow
-                    ? new ElevationRange { Min = sequence.MinElevation, Max = sequence.MaxElevation }
-                    : null,
-                GridDimensions = sequence.IsMultiRow
-                    ? $"{sequence.ElevationTierCount}x{sequence.AzimuthColumnCount}"
-                    : null,
-                VerticalCoverageDegrees = sequence.IsMultiRow
-                    ? sequence.MaxElevation - sequence.MinElevation
-                    : null,
-                Stitch = stitchInfo
-            },
-            Links = new PanoramaLinks
-            {
-                StitchedPreview = stitchRecord?.Status == "completed"
-                    ? $"/stitch/{panoramaId}/image"
-                    : null,
-                DownloadSet = $"/api/v2/panoramas/{panoramaId}/download"
-            }
-        };
-    }
-
-    /// <summary>
-    /// Get panorama ID string from a sequence
-    /// </summary>
-    private static string GetPanoramaId(PanoramaSequence sequence)
-    {
-        var first = sequence.Photos.First();
-        return $"pano_{first.Rover.Name.ToLowerInvariant()}_{first.Sol}_{sequence.Index}";
     }
 
     /// <summary>

--- a/src/MarsVista.Api/Services/V2/PanoramaService.cs
+++ b/src/MarsVista.Api/Services/V2/PanoramaService.cs
@@ -218,19 +218,23 @@ public class PanoramaService : IPanoramaService
         string panoramaId,
         CancellationToken cancellationToken = default)
     {
-        var sequence = await DetectPanoramaSequenceByIdAsync(panoramaId, cancellationToken);
-        if (sequence == null)
+        var entity = await _context.Panoramas
+            .AsNoTracking()
+            .Include(p => p.Rover)
+            .Include(p => p.Camera)
+            .FirstOrDefaultAsync(p => p.PanoramaId == panoramaId, cancellationToken);
+
+        if (entity == null)
             return null;
 
         var stitchRecord = await _context.StitchedPanoramas
             .AsNoTracking()
             .FirstOrDefaultAsync(s => s.PanoramaId == panoramaId, cancellationToken);
 
-        var stitchStatuses = stitchRecord != null
+        var stitchMap = stitchRecord != null
             ? new Dictionary<string, StitchedPanorama> { { panoramaId, stitchRecord } }
-            : null;
+            : new Dictionary<string, StitchedPanorama>();
 
-        // Load rating aggregate for this panorama
         var ratingData = await _context.PanoramaRatings
             .AsNoTracking()
             .Where(r => r.PanoramaId == panoramaId)
@@ -238,12 +242,11 @@ public class PanoramaService : IPanoramaService
             .Select(g => new { Avg = g.Average(r => r.Rating), Count = g.Count() })
             .FirstOrDefaultAsync(cancellationToken);
 
-        var ratingAggregates = ratingData != null
+        var ratingMap = ratingData != null
             ? new Dictionary<string, RatingAggregate> { { panoramaId, new RatingAggregate(ratingData.Avg, ratingData.Count) } }
-            : null;
+            : new Dictionary<string, RatingAggregate>();
 
-        // Map constituent photos to PhotoResource for detail response
-        var photoIds = sequence.Photos.Select(p => p.Id).ToList();
+        // Load the constituent photos (by the stored photo_ids) for the detail response
         var photoParams = new Models.V2.PhotoQueryParameters
         {
             Include = "rover,camera",
@@ -251,9 +254,9 @@ public class PanoramaService : IPanoramaService
             IncludeList = new List<string> { "rover", "camera" },
             FieldSetParsed = Models.V2.FieldSetType.Extended
         };
-        var photoResources = await _photoService.GetPhotosByIdsAsync(photoIds, photoParams, cancellationToken);
+        var photoResources = await _photoService.GetPhotosByIdsAsync(entity.PhotoIds.ToList(), photoParams, cancellationToken);
 
-        return ToPanoramaResource(sequence, stitchStatuses, photoResources, ratingAggregates);
+        return MapEntityToResource(entity, stitchMap, ratingMap, photoResources);
     }
 
     public async Task<RatingResponse> UpsertRatingAsync(

--- a/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
+++ b/src/MarsVista.Core/Services/PanoramaTableBuilder.cs
@@ -21,6 +21,13 @@ public interface IPanoramaTableBuilder
     /// panoramas written.
     /// </summary>
     Task<int> RebuildSolAsync(int roverId, int sol, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rebuilds every sol in [startSol, endSol] for one rover. Used by the daily
+    /// scraper to refresh the sols it just scraped. Returns the total number of
+    /// panoramas written across the window.
+    /// </summary>
+    Task<int> RebuildSolRangeAsync(int roverId, int startSol, int endSol, CancellationToken cancellationToken = default);
 }
 
 public class PanoramaTableBuilder : IPanoramaTableBuilder
@@ -97,6 +104,16 @@ public class PanoramaTableBuilder : IPanoramaTableBuilder
 
         _logger.LogDebug("Rebuilt {Count} panoramas for rover {RoverId} sol {Sol}", rows.Count, roverId, sol);
         return rows.Count;
+    }
+
+    public async Task<int> RebuildSolRangeAsync(int roverId, int startSol, int endSol, CancellationToken cancellationToken = default)
+    {
+        var total = 0;
+        for (var sol = startSol; sol <= endSol; sol++)
+        {
+            total += await RebuildSolAsync(roverId, sol, cancellationToken);
+        }
+        return total;
     }
 
     /// <summary>

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -178,6 +178,38 @@ try
         Environment.ExitCode = 1; // Non-zero exit code for Railway monitoring
     }
 
+    // Best-effort: refresh the panoramas table for the sols each rover scraped,
+    // so new photos are reflected in pre-computed panoramas. Own try/catch so a
+    // refresh failure is logged but never changes the scrape's exit code.
+    try
+    {
+        using var panoramaScope = host.Services.CreateScope();
+        var panoramaContext = panoramaScope.ServiceProvider.GetRequiredService<MarsVistaDbContext>();
+        var panoramaBuilder = panoramaScope.ServiceProvider
+            .GetRequiredService<MarsVista.Core.Services.IPanoramaTableBuilder>();
+
+        var totalRefreshed = 0;
+        foreach (var roverResult in result.RoverResults.Where(r => r.Success))
+        {
+            var rover = await panoramaContext.Rovers
+                .FirstOrDefaultAsync(r => r.Name.ToLower() == roverResult.RoverName.ToLower());
+            if (rover == null)
+            {
+                Log.Warning("Panorama refresh: unknown rover {Rover}, skipping", roverResult.RoverName);
+                continue;
+            }
+
+            totalRefreshed += await panoramaBuilder.RebuildSolRangeAsync(
+                rover.Id, roverResult.StartSol, roverResult.EndSol);
+        }
+
+        Log.Information("Panorama refresh complete: {Count} panoramas rebuilt across scraped sols", totalRefreshed);
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Panorama refresh failed (scrape result unaffected)");
+    }
+
     // Best-effort daily maintenance. Wrapped so a retention failure is logged
     // but never changes the scrape's exit code - the scrape is the job that
     // Railway monitors, not the cleanup.

--- a/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
@@ -95,6 +95,39 @@ public class PanoramaTableBuilderTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task RebuildSolRange_RebuildsEverySolInWindow()
+    {
+        // Seed a second panorama at sol 1001 (the base seed covers sol 1000).
+        var now = DateTime.UtcNow;
+        for (int i = 0; i < 5; i++)
+        {
+            DbContext.Photos.Add(new Photo
+            {
+                NasaId = $"NRF_1001_{i:D4}",
+                Sol = 1001,
+                EarthDate = new DateTime(2015, 5, 31, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 5, 31, 10, i, 0, DateTimeKind.Utc),
+                DateTakenMars = $"Sol-1001M14:0{i}:00",
+                ImgSrcSmall = "s", ImgSrcMedium = "m", ImgSrcLarge = "l", ImgSrcFull = "f",
+                Site = 79, Drive = 1204,
+                MastAz = 45.0f + (i * 10.0f),
+                MastEl = -10.0f,
+                SpacecraftClock = 813073000.0f + (i * 100.0f),
+                RoverId = RoverId, CameraId = 2,
+                CreatedAt = now, UpdatedAt = now,
+            });
+        }
+        await DbContext.SaveChangesAsync();
+
+        // Range spans an empty trailing sol (1002) to prove it is handled without error.
+        var written = await _builder.RebuildSolRangeAsync(RoverId, Sol, 1002);
+
+        written.Should().Be(2, "sols 1000 and 1001 each form one panorama; 1002 has none");
+        DbContext.Panoramas.AsEnumerable().Select(p => p.Sol).OrderBy(s => s)
+            .Should().Equal(1000, 1001);
+    }
+
+    [Fact]
     public async Task Rebuild_IsIdempotent()
     {
         var first = await _builder.RebuildSolAsync(RoverId, Sol);

--- a/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/PanoramaTableBuilderTests.cs
@@ -63,13 +63,15 @@ public class PanoramaTableBuilderTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task BuilderRow_MatchesLiveDetection()
+    public async Task BuilderRow_MatchesServedResource()
     {
+        // Build the table, then read it back through the (now table-backed) service:
+        // the served DTO must reflect the stored row field-for-field.
+        await _builder.RebuildSolAsync(RoverId, Sol);
+
         var live = await _panoramaService.GetPanoramasAsync(
             rovers: "curiosity", solMin: Sol, solMax: Sol, pageSize: 50);
-        live.Data.Should().NotBeEmpty("the seed forms a detectable panorama");
-
-        await _builder.RebuildSolAsync(RoverId, Sol);
+        live.Data.Should().NotBeEmpty("the built table has a panorama for this sol");
 
         foreach (var dto in live.Data!)
         {

--- a/tests/MarsVista.Api.Tests/Integration/V2/PanoramasIntegrationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PanoramasIntegrationTests.cs
@@ -18,6 +18,31 @@ public class PanoramasIntegrationTests : IntegrationTestBase
         services.AddScoped<IPanoramaService, PanoramaService>();
     }
 
+    // Populates the panoramas table from the seeded photos (as the scraper does),
+    // then delegates to the table-backed GetPanoramasAsync.
+    private async Task RebuildPanoramaTableAsync()
+    {
+        var detector = ServiceProvider.GetRequiredService<MarsVista.Core.Services.PanoramaDetector>();
+        var builder = new MarsVista.Core.Services.PanoramaTableBuilder(
+            DbContext, detector,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaTableBuilder>.Instance);
+        var runner = new MarsVista.Core.Services.PanoramaBackfillRunner(
+            DbContext, builder,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaBackfillRunner>.Instance);
+        await runner.RunAsync();
+    }
+
+    private async Task<ApiResponse<List<PanoramaResource>>> RebuildThenList(
+        string? rovers = null, int? solMin = null, int? solMax = null, int? minPhotos = null,
+        string? stitchStatus = null, string? stitchMethod = null, string? mosaicType = null,
+        string? quality = null, double? minRating = null, string? sort = null, string? order = null,
+        int pageNumber = 1, int pageSize = 25, CancellationToken cancellationToken = default)
+    {
+        await RebuildPanoramaTableAsync();
+        return await _panoramaService.GetPanoramasAsync(rovers, solMin, solMax, minPhotos, stitchStatus,
+            stitchMethod, mosaicType, quality, minRating, sort, order, pageNumber, pageSize, cancellationToken);
+    }
+
     protected override async Task SeedAdditionalDataAsync()
     {
         _panoramaService = ServiceProvider.GetRequiredService<IPanoramaService>();
@@ -110,10 +135,31 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task GetPanoramas_ReadsTable_WithDbLevelPagination_NoPhotoScan()
+    {
+        await RebuildPanoramaTableAsync();
+        SqlCapture.Clear();
+
+        await _panoramaService.GetPanoramasAsync(
+            rovers: "curiosity", solMin: 0, solMax: 2000, pageNumber: 1, pageSize: 2);
+
+        var sqls = SqlCapture.ExecutedSql;
+        sqls.Should().Contain(
+            s => s.Contains("FROM panoramas", StringComparison.OrdinalIgnoreCase)
+                 && s.Contains("LIMIT", StringComparison.OrdinalIgnoreCase),
+            "the list endpoint reads the pre-computed table with DB-level pagination");
+        sqls.Should().NotContain(
+            s => s.Contains("FROM photos", StringComparison.OrdinalIgnoreCase),
+            "the list path must not scan the photos table - detection is pre-computed");
+        sqls.Count.Should().BeLessThan(8,
+            "a bounded number of statements, not a per-sol detection loop");
+    }
+
+    [Fact]
     public async Task GetPanoramas_ReturnsDetectedPanoramas()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: null, // All rovers
             solMin: 0, // Explicit range to include all test data (overrides default 500-sol limit)
             solMax: 2000,
@@ -131,7 +177,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_WithRoverFilter_FiltersCorrectly()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -145,7 +191,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_WithSolFilter_FiltersCorrectly()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -161,7 +207,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_WithMinPhotosFilter_FiltersCorrectly()
     {
         // Act - Require at least 5 photos
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: null,
             solMin: 0, // Explicit range to include all test data (overrides default 500-sol limit)
             solMax: 2000,
@@ -178,7 +224,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_ReturnsCompleteStructure()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -201,7 +247,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_IncludesLocationData()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -218,7 +264,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_WithPagination_ReturnsCorrectPage()
     {
         // Act - Get first page
-        var page1 = await _panoramaService.GetPanoramasAsync(
+        var page1 = await RebuildThenList(
             rovers: null,
             solMin: 0, // Explicit range to include all test data (overrides default 500-sol limit)
             solMax: 2000,
@@ -236,7 +282,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramaById_WithValidId_ReturnsPanorama()
     {
         // Arrange - Get all panoramas first to get a valid ID
-        var allPanoramas = await _panoramaService.GetPanoramasAsync(
+        var allPanoramas = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -266,7 +312,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_CalculatesCorrectCoverage()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -283,7 +329,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_IncludesMarsTimeRange()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -298,7 +344,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_IncludesAverageElevation()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -314,7 +360,7 @@ public class PanoramasIntegrationTests : IntegrationTestBase
     public async Task GetPanoramas_IncludesCameraName()
     {
         // Act
-        var response = await _panoramaService.GetPanoramasAsync(
+        var response = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);

--- a/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
+++ b/tests/MarsVista.Api.Tests/Services/V2/PanoramaFilterAndRatingTests.cs
@@ -25,6 +25,31 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
         services.AddScoped<PanoramaService>();
     }
 
+    // Populates the panoramas table from the seeded photos (as the scraper does),
+    // then delegates to the table-backed GetPanoramasAsync.
+    private async Task RebuildPanoramaTableAsync()
+    {
+        var detector = ServiceProvider.GetRequiredService<MarsVista.Core.Services.PanoramaDetector>();
+        var builder = new MarsVista.Core.Services.PanoramaTableBuilder(
+            DbContext, detector,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaTableBuilder>.Instance);
+        var runner = new MarsVista.Core.Services.PanoramaBackfillRunner(
+            DbContext, builder,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaBackfillRunner>.Instance);
+        await runner.RunAsync();
+    }
+
+    private async Task<MarsVista.Api.DTOs.V2.ApiResponse<List<MarsVista.Api.DTOs.V2.PanoramaResource>>> RebuildThenList(
+        string? rovers = null, int? solMin = null, int? solMax = null, int? minPhotos = null,
+        string? stitchStatus = null, string? stitchMethod = null, string? mosaicType = null,
+        string? quality = null, double? minRating = null, string? sort = null, string? order = null,
+        int pageNumber = 1, int pageSize = 25, CancellationToken cancellationToken = default)
+    {
+        await RebuildPanoramaTableAsync();
+        return await _service.GetPanoramasAsync(rovers, solMin, solMax, minPhotos, stitchStatus,
+            stitchMethod, mosaicType, quality, minRating, sort, order, pageNumber, pageSize, cancellationToken);
+    }
+
     protected override async Task SeedAdditionalDataAsync()
     {
         _service = ServiceProvider.GetRequiredService<PanoramaService>();
@@ -126,7 +151,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_StitchStatusCompleted_FiltersToStitchedOnly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchStatus: "completed",
             pageNumber: 1,
             pageSize: 25);
@@ -140,7 +165,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_StitchStatusFailed_FiltersToFailedOnly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchStatus: "failed",
             pageNumber: 1,
             pageSize: 25);
@@ -155,7 +180,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     public async Task GetPanoramasAsync_StitchStatusNotStarted_ExcludesStitched()
     {
         // Both panoramas have stitch records, so not_started should return empty
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchStatus: "not_started",
             pageNumber: 1,
             pageSize: 25);
@@ -168,7 +193,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_StitchMethodFeatureMatch_FiltersCorrectly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchMethod: "feature_match",
             pageNumber: 1,
             pageSize: 25);
@@ -181,7 +206,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_StitchMethodTelemetryProjection_ReturnsEmpty()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchMethod: "telemetry_projection",
             pageNumber: 1,
             pageSize: 25);
@@ -194,7 +219,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_QualityWide_FiltersCorrectly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             quality: "wide",
             pageNumber: 1,
             pageSize: 25);
@@ -207,7 +232,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_QualityPartial_FiltersCorrectly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             quality: "partial",
             pageNumber: 1,
             pageSize: 25);
@@ -222,7 +247,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_MosaicTypeSingleRow_FiltersCorrectly()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             mosaicType: "single_row",
             pageNumber: 1,
             pageSize: 25);
@@ -234,7 +259,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_MosaicTypeMultiRow_ReturnsEmpty()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             mosaicType: "multi_row",
             pageNumber: 1,
             pageSize: 25);
@@ -248,7 +273,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     public async Task GetPanoramasAsync_MinRating4_FiltersToHighRatedOnly()
     {
         // Panorama 2 has ratings 5+3=8/2=4.0 avg
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             minRating: 4.0,
             pageNumber: 1,
             pageSize: 25);
@@ -261,7 +286,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     public async Task GetPanoramasAsync_MinRating5_ReturnsEmpty()
     {
         // Average is 4.0, so min_rating=5 excludes everything
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             minRating: 5.0,
             pageNumber: 1,
             pageSize: 25);
@@ -274,7 +299,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_SortByPhotosDesc_HighestFirst()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             sort: "photos",
             order: "desc",
             pageNumber: 1,
@@ -288,7 +313,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_SortByPhotosAsc_LowestFirst()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             sort: "photos",
             order: "asc",
             pageNumber: 1,
@@ -304,7 +329,7 @@ public class PanoramaFilterAndRatingTests : IntegrationTestBase
     [Fact]
     public async Task GetPanoramasAsync_CompletedStitch_IncludesStitchInfo()
     {
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             stitchStatus: "completed",
             pageNumber: 1,
             pageSize: 25);

--- a/tests/MarsVista.Api.Tests/Services/V2/PanoramaServiceTests.cs
+++ b/tests/MarsVista.Api.Tests/Services/V2/PanoramaServiceTests.cs
@@ -26,6 +26,32 @@ public class PanoramaServiceTests : IntegrationTestBase
         services.AddScoped<PanoramaService>();
     }
 
+    // Populates the panoramas table from the seeded photos (as the scraper does),
+    // then delegates to the now table-backed GetPanoramasAsync. Lets the existing
+    // detection-behaviour assertions run against the pre-computed read path.
+    private async Task RebuildPanoramaTableAsync()
+    {
+        var detector = ServiceProvider.GetRequiredService<MarsVista.Core.Services.PanoramaDetector>();
+        var builder = new MarsVista.Core.Services.PanoramaTableBuilder(
+            DbContext, detector,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaTableBuilder>.Instance);
+        var runner = new MarsVista.Core.Services.PanoramaBackfillRunner(
+            DbContext, builder,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MarsVista.Core.Services.PanoramaBackfillRunner>.Instance);
+        await runner.RunAsync();
+    }
+
+    private async Task<ApiResponse<List<PanoramaResource>>> RebuildThenList(
+        string? rovers = null, int? solMin = null, int? solMax = null, int? minPhotos = null,
+        string? stitchStatus = null, string? stitchMethod = null, string? mosaicType = null,
+        string? quality = null, double? minRating = null, string? sort = null, string? order = null,
+        int pageNumber = 1, int pageSize = 25, CancellationToken cancellationToken = default)
+    {
+        await RebuildPanoramaTableAsync();
+        return await _service.GetPanoramasAsync(rovers, solMin, solMax, minPhotos, stitchStatus,
+            stitchMethod, mosaicType, quality, minRating, sort, order, pageNumber, pageSize, cancellationToken);
+    }
+
     protected override async Task SeedAdditionalDataAsync()
     {
         // Get service after initialization
@@ -113,7 +139,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_WithValidData_DetectsPanorama()
     {
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -163,7 +189,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act - Filter for sol 1000 only
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -179,7 +205,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_WithMinPhotosFilter_FiltersCorrectly()
     {
         // Act - Require at least 10 photos (should exclude our 5-photo panorama)
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             minPhotos: 10,
             pageNumber: 1,
@@ -224,7 +250,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act - Get page 2 with page size 10
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 2,
             pageSize: 10);
@@ -267,7 +293,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -284,7 +310,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         var panoramaId = "pano_curiosity_1000_0";
 
         // First, get all panoramas to find the actual ID
-        var allPanoramas = await _service.GetPanoramasAsync(
+        var allPanoramas = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -375,7 +401,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act - Get panoramas list first
-        var allPanoramas = await _service.GetPanoramasAsync(
+        var allPanoramas = await RebuildThenList(
             rovers: "curiosity",
             solMin: 6000,
             solMax: 6000,
@@ -456,7 +482,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -500,7 +526,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4000,
             solMax: 4000,
@@ -567,7 +593,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 5000,
             solMax: 5000,
@@ -611,7 +637,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             solMin: 1000,
             solMax: 1000,
             pageNumber: 1,
@@ -631,7 +657,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -684,7 +710,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4278,
             solMax: 4278,
@@ -734,7 +760,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4279,
             solMax: 4279,
@@ -787,7 +813,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4280,
             solMax: 4280,
@@ -802,7 +828,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_ReturnsQualityMetadata()
     {
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -847,7 +873,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4281,
             solMax: 4281,
@@ -893,7 +919,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4282,
             solMax: 4282,
@@ -911,7 +937,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_IncludesLocationInformation()
     {
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -929,7 +955,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_CalculatesAverageElevation()
     {
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -943,7 +969,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_IncludesDownloadLink()
     {
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             pageNumber: 1,
             pageSize: 25);
@@ -992,7 +1018,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 4500,
             solMax: 4500,
@@ -1051,7 +1077,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7000,
             solMax: 7000,
@@ -1144,7 +1170,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7001,
             solMax: 7001,
@@ -1161,7 +1187,7 @@ public class PanoramaServiceTests : IntegrationTestBase
     public async Task GetPanoramasAsync_SingleRow_HasCorrectNewFields()
     {
         // Act - Use seed data (5 photos, all at -10° elevation)
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 1000,
             solMax: 1000,
@@ -1240,7 +1266,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7002,
             solMax: 7002,
@@ -1295,7 +1321,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7003,
             solMax: 7003,
@@ -1375,7 +1401,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7010,
             solMax: 7010,
@@ -1456,7 +1482,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7011,
             solMax: 7011,
@@ -1507,7 +1533,7 @@ public class PanoramaServiceTests : IntegrationTestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var result = await _service.GetPanoramasAsync(
+        var result = await RebuildThenList(
             rovers: "curiosity",
             solMin: 7004,
             solMax: 7004,


### PR DESCRIPTION
## Summary

Completes the panorama pre-compute work: the `/api/v2/panoramas` endpoints now read the `panoramas` table (backfilled + kept fresh by the scraper) instead of detecting from the photos table on every request. This turns the **6–9 s** per-request N+1 detection loop into a bounded, indexed table query.

**Prerequisite met:** the production backfill ran and passed the zero-orphan gate (7,660 panoramas; all 9 stitched images and every real rating resolve). So the table is populated before this deploys.

### Commits

1. **List endpoint reads the table** — `GetPanoramasAsync` is now an EF query over `panoramas` with all filtering (rover, sol range, min photos, mosaic type, quality, stitch status/method, min rating), sorting (sol, coverage, photos, rating), and pagination in the database. Rover filter resolves via the static reference cache (not a name join — story 052a). `min_rating` uses a pre-aggregated non-correlated subquery. A SqlCapture test asserts the list path hits `panoramas` with `LIMIT` and never scans `photos`.
2. **Detail endpoint reads the table** — `GetPanoramaByIdAsync` looks up by id and loads constituent photos from the stored `photo_ids`.
3. **Daily incremental refresh** — after each successful rover scrape, the scraper rebuilds the panoramas for the sols it scraped (`RebuildSolRangeAsync`), own try/catch so it never affects the scrape's exit code.
4. **Cleanup** — remove the dead request-time detection (`DetectPanoramaSequenceByIdAsync`, sequence-based mapper, injected `PanoramaDetector`); detection now lives solely in Core for the scraper. Decision doc marked implemented; `min_photos` clarified (now a `total_photos >= N` filter, not a re-detection, so ids stay stable).

## Behaviour parity

The ~60 detection-behaviour tests were preserved: they now populate the table from their seeded photos (as the scraper does) and read it back, so every existing assertion on coverage, quality, mosaic geometry, mars-time normalization, filters, and ratings still holds. Full suite: **471 tests green**.

## One intentional semantics change

`min_photos > 3` previously re-ran detection and could reassign sequence indices (a latent id-instability bug). It's now a filter over the stored panorama set, so ids are stable regardless of the filter.

## Post-deploy verification

- `time curl "https://api.marsvista.dev/api/v2/panoramas"` → expect <300 ms (was 6–9 s); also with `rovers=`, `quality=`, `stitch_status=`, `sort=` variants.
- A known stitched id (e.g. `pano_curiosity_4321_0`) returns `stitch.status=completed`.
- `pg_statio_user_tables` shows the panorama-driven `photos` reads gone.
- Space app: first page of no-filter panoramas shows recent Curiosity panoramas.
- Watch the next 2 AM scraper log for `Panorama refresh complete`.

## Notes

- Adds a Core method (`RebuildSolRangeAsync`) → bump the ops Core submodule after merge.
- No migration in this PR (the table shipped in the foundation PR).