### PR TITLE
Fix unobserved ObjectDisposedException in usage tracking middleware

### DIFF
--- a/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
+++ b/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
@@ -14,13 +14,16 @@ public class UsageTrackingMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<UsageTrackingMiddleware> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     public UsageTrackingMiddleware(
         RequestDelegate next,
-        ILogger<UsageTrackingMiddleware> logger)
+        ILogger<UsageTrackingMiddleware> logger,
+        IServiceScopeFactory scopeFactory)
     {
         _next = next;
         _logger = logger;
+        _scopeFactory = scopeFactory;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -59,8 +62,16 @@ public class UsageTrackingMiddleware
             await responseBody.CopyToAsync(originalBodyStream);
             context.Response.Body = originalBodyStream;
 
-            // Track usage (fire-and-forget)
-            _ = TrackUsageAsync(context, stopwatch.ElapsedMilliseconds, errorDetail);
+            // Build the usage event while the HttpContext is still alive, then
+            // persist it fire-and-forget. The detached task must NOT touch the
+            // HttpContext: once the response completes the framework recycles the
+            // context and its IFeatureCollection, so any later access throws
+            // ObjectDisposedException on the unobserved task.
+            var usageEvent = BuildUsageEvent(context, stopwatch.ElapsedMilliseconds, errorDetail);
+            if (usageEvent is not null)
+            {
+                _ = TrackUsageAsync(usageEvent);
+            }
         }
     }
 
@@ -120,60 +131,77 @@ public class UsageTrackingMiddleware
     }
 
     /// <summary>
-    /// Asynchronously tracks the usage event without blocking the response.
+    /// Builds the usage event from the request/response while the HttpContext is
+    /// still alive. Returns null for unauthenticated requests (nothing to track).
     /// </summary>
-    private async Task TrackUsageAsync(HttpContext context, long responseTimeMs, string? errorDetail)
+    private static UsageEvent? BuildUsageEvent(HttpContext context, long responseTimeMs, string? errorDetail)
+    {
+        // Extract user context (set by authentication middleware)
+        var userEmail = context.Items["UserEmail"] as string;
+        if (string.IsNullOrEmpty(userEmail))
+        {
+            // No authenticated user - nothing to track
+            return null;
+        }
+
+        var userTier = context.Items["UserTier"] as string;
+
+        // Count photos returned (if applicable)
+        var photosReturned = context.Items.TryGetValue("PhotosReturned", out var value) && value is int count
+            ? count
+            : 0;
+
+        // Capture query string for error requests
+        var queryString = context.Request.QueryString.HasValue
+            ? context.Request.QueryString.Value
+            : null;
+
+        return new UsageEvent
+        {
+            UserEmail = userEmail,
+            Tier = userTier ?? "free",
+            Endpoint = context.Request.Path,
+            StatusCode = context.Response.StatusCode,
+            ResponseTimeMs = (int)responseTimeMs,
+            PhotosReturned = photosReturned,
+            QueryString = queryString,
+            ErrorDetail = errorDetail,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Persists the usage event fire-and-forget, without blocking the response.
+    /// Detached from the request: it works only with the pre-built
+    /// <paramref name="usageEvent"/> and never dereferences the HttpContext, which
+    /// may already be disposed by the time this runs.
+    /// </summary>
+    private async Task TrackUsageAsync(UsageEvent usageEvent)
     {
         try
         {
-            // Extract user context (set by authentication middleware)
-            var userEmail = context.Items["UserEmail"] as string;
-            var userTier = context.Items["UserTier"] as string;
-
-            if (string.IsNullOrEmpty(userEmail))
-            {
-                // No authenticated user - skip tracking
-                return;
-            }
-
-            // Count photos returned (if applicable)
-            var photosReturned = 0;
-            if (context.Items.ContainsKey("PhotosReturned"))
-            {
-                photosReturned = (int)(context.Items["PhotosReturned"] ?? 0);
-            }
-
-            // Capture query string for error requests
-            var queryString = context.Request.QueryString.HasValue
-                ? context.Request.QueryString.Value
-                : null;
-
-            // Create usage event
-            var usageEvent = new UsageEvent
-            {
-                UserEmail = userEmail,
-                Tier = userTier ?? "free",
-                Endpoint = context.Request.Path,
-                StatusCode = context.Response.StatusCode,
-                ResponseTimeMs = (int)responseTimeMs,
-                PhotosReturned = photosReturned,
-                QueryString = queryString,
-                ErrorDetail = errorDetail,
-                CreatedAt = DateTime.UtcNow
-            };
-
-            // Save to database (use a new scope to avoid issues with disposed contexts)
-            using var scope = context.RequestServices.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<MarsVistaDbContext>();
-
-            dbContext.UsageEvents.Add(usageEvent);
-            await dbContext.SaveChangesAsync();
+            await PersistAsync(usageEvent);
         }
         catch (Exception ex)
         {
-            // Log error but don't fail the request
-            _logger.LogError(ex, "Failed to track usage event for {Path}", context.Request.Path);
+            // Log with the captured endpoint - touching the HttpContext here would
+            // throw a second, unobserved ObjectDisposedException on this task.
+            _logger.LogError(ex, "Failed to track usage event for {Path}", usageEvent.Endpoint);
         }
+    }
+
+    /// <summary>
+    /// Writes the usage event to the database using a fresh DI scope from the
+    /// application root, independent of the request scope (which ends with the
+    /// response). Virtual so tests can simulate persistence failures.
+    /// </summary>
+    protected virtual async Task PersistAsync(UsageEvent usageEvent)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MarsVistaDbContext>();
+
+        dbContext.UsageEvents.Add(usageEvent);
+        await dbContext.SaveChangesAsync();
     }
 
     /// <summary>

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using MarsVista.Api.Middleware;
+using MarsVista.Core.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace MarsVista.Api.Tests.Middleware;
+
+/// <summary>
+/// Regression coverage for the production crash in
+/// <see cref="UsageTrackingMiddleware"/> where the fire-and-forget usage-tracking
+/// task dereferenced the HttpContext after the response completed. Once the
+/// response is sent the framework recycles the context and its
+/// <c>IFeatureCollection</c>; when the database write failed, the catch handler
+/// logged <c>context.Request.Path</c> and threw a second
+/// <c>ObjectDisposedException: IFeatureCollection has been disposed</c> that
+/// escaped as an unobserved task exception (Sentry MARS-VISTA-API-G, 39 events).
+///
+/// The fix snapshots everything into a <see cref="UsageEvent"/> while the context
+/// is alive and never touches the context on the detached task. These tests pin
+/// that contract: the snapshot is built from the live request, and a persistence
+/// failure is swallowed and logged from captured state alone.
+/// </summary>
+public class UsageTrackingMiddlewareTests
+{
+    [Fact]
+    public async Task PersistenceFailure_IsSwallowedAndLogged_WithoutSurfacingException()
+    {
+        var logger = new Mock<ILogger<UsageTrackingMiddleware>>();
+        var databaseFailure = new InvalidOperationException("simulated database failure");
+
+        var middleware = new TestableUsageTrackingMiddleware(
+            next: _ => Task.CompletedTask,
+            logger: logger.Object,
+            persist: _ => throw databaseFailure);
+
+        var context = BuildAuthenticatedContext("/api/v2/photos/2863558");
+
+        // The fire-and-forget tracking failure must never propagate into the
+        // request pipeline.
+        var invoke = () => middleware.InvokeAsync(context);
+        await invoke.Should().NotThrowAsync();
+
+        // The failure was caught and logged using the captured endpoint - proving
+        // the catch handler did not dereference the (recycled) HttpContext, which
+        // is exactly what threw the secondary ObjectDisposedException in production.
+        VerifyLoggedError(logger, databaseFailure, "/api/v2/photos/2863558");
+    }
+
+    [Fact]
+    public async Task BuildsUsageEventSnapshot_FromLiveRequestAndResponse()
+    {
+        UsageEvent? captured = null;
+
+        var middleware = new TestableUsageTrackingMiddleware(
+            next: ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; },
+            logger: Mock.Of<ILogger<UsageTrackingMiddleware>>(),
+            persist: usageEvent => { captured = usageEvent; return Task.CompletedTask; });
+
+        var context = BuildAuthenticatedContext(
+            "/api/v2/photos/42", tier: "pro", query: "?include=rover,camera");
+        context.Items["PhotosReturned"] = 1;
+
+        await middleware.InvokeAsync(context);
+
+        captured.Should().NotBeNull();
+        captured!.UserEmail.Should().Be("test@marsvista.dev");
+        captured.Tier.Should().Be("pro");
+        captured.Endpoint.Should().Be("/api/v2/photos/42");
+        captured.StatusCode.Should().Be(200);
+        captured.QueryString.Should().Be("?include=rover,camera");
+        captured.PhotosReturned.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UnauthenticatedRequest_IsNotTracked()
+    {
+        var persisted = false;
+
+        var middleware = new TestableUsageTrackingMiddleware(
+            next: _ => Task.CompletedTask,
+            logger: Mock.Of<ILogger<UsageTrackingMiddleware>>(),
+            persist: _ => { persisted = true; return Task.CompletedTask; });
+
+        // No UserEmail in Items -> the request is anonymous.
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/v2/photos/42";
+
+        await middleware.InvokeAsync(context);
+
+        persisted.Should().BeFalse();
+    }
+
+    private static DefaultHttpContext BuildAuthenticatedContext(
+        string path, string tier = "free", string? query = null)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        if (query is not null)
+        {
+            context.Request.QueryString = new QueryString(query);
+        }
+
+        context.Items["UserEmail"] = "test@marsvista.dev";
+        context.Items["UserTier"] = tier;
+        return context;
+    }
+
+    private static void VerifyLoggedError(
+        Mock<ILogger<UsageTrackingMiddleware>> logger, Exception expected, string endpointFragment)
+    {
+        logger.Verify(l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains(endpointFragment)),
+                expected,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Overrides the database write with a supplied delegate so tests can capture
+    /// the built event or simulate a persistence failure without a database.
+    /// </summary>
+    private sealed class TestableUsageTrackingMiddleware : UsageTrackingMiddleware
+    {
+        private readonly Func<UsageEvent, Task> _persist;
+
+        public TestableUsageTrackingMiddleware(
+            RequestDelegate next,
+            ILogger<UsageTrackingMiddleware> logger,
+            Func<UsageEvent, Task> persist)
+            : base(next, logger, Mock.Of<IServiceScopeFactory>())
+        {
+            _persist = persist;
+        }
+
+        protected override Task PersistAsync(UsageEvent usageEvent) => _persist(usageEvent);
+    }
+}

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -1,7 +1,9 @@
+using System.Collections;
 using FluentAssertions;
 using MarsVista.Api.Middleware;
 using MarsVista.Core.Entities;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -20,8 +22,9 @@ namespace MarsVista.Api.Tests.Middleware;
 ///
 /// The fix snapshots everything into a <see cref="UsageEvent"/> while the context
 /// is alive and never touches the context on the detached task. These tests pin
-/// that contract: the snapshot is built from the live request, and a persistence
-/// failure is swallowed and logged from captured state alone.
+/// that contract: the snapshot is built from the live request; a persistence
+/// failure is swallowed and logged from captured state; and, with the context
+/// deliberately recycled mid-flight, the detached task never dereferences it.
 /// </summary>
 public class UsageTrackingMiddlewareTests
 {
@@ -43,9 +46,55 @@ public class UsageTrackingMiddlewareTests
         var invoke = () => middleware.InvokeAsync(context);
         await invoke.Should().NotThrowAsync();
 
-        // The failure was caught and logged using the captured endpoint - proving
-        // the catch handler did not dereference the (recycled) HttpContext, which
-        // is exactly what threw the secondary ObjectDisposedException in production.
+        // The failure is swallowed and logged from the captured snapshot, so the
+        // fire-and-forget task completes instead of faulting. (That the catch never
+        // touches the recycled HttpContext is proven separately by
+        // PersistenceFailureAfterContextRecycled_DoesNotDereferenceContext, which
+        // runs the error path against a disposed feature collection.)
+        VerifyLoggedError(logger, databaseFailure, "/api/v2/photos/2863558");
+    }
+
+    [Fact]
+    public async Task PersistenceFailureAfterContextRecycled_DoesNotDereferenceContext()
+    {
+        UsageEvent? snapshot = null;
+        var logger = new Mock<ILogger<UsageTrackingMiddleware>>();
+        var databaseFailure = new InvalidOperationException("simulated database failure");
+
+        var (context, features) = BuildRecyclableAuthenticatedContext(
+            "/api/v2/photos/2863558", "?include=rover,camera");
+
+        // Reproduce the production timing: the fire-and-forget task's error path
+        // runs after the framework has recycled the HttpContext. The delegate
+        // captures the (already materialized) snapshot, disposes the feature
+        // collection, then fails the persistence.
+        var middleware = new TestableUsageTrackingMiddleware(
+            next: _ => Task.CompletedTask,
+            logger: logger.Object,
+            persist: usageEvent =>
+            {
+                snapshot = usageEvent;
+                features.Recycle();
+                throw databaseFailure;
+            });
+
+        var invoke = () => middleware.InvokeAsync(context);
+
+        // The recycled context must not surface into the request pipeline...
+        await invoke.Should().NotThrowAsync();
+
+        // ...the feature collection really is disposed now (guards the test itself)...
+        var touchRecycledContext = () => _ = context.Request.Path;
+        touchRecycledContext.Should().Throw<ObjectDisposedException>();
+
+        // ...the snapshot was fully materialized before recycling...
+        snapshot.Should().NotBeNull();
+        snapshot!.Endpoint.Should().Be("/api/v2/photos/2863558");
+        snapshot.UserEmail.Should().Be("test@marsvista.dev");
+
+        // ...and the failure was logged from that snapshot, never from the dead
+        // context - which is exactly what threw the secondary ObjectDisposedException
+        // in production.
         VerifyLoggedError(logger, databaseFailure, "/api/v2/photos/2863558");
     }
 
@@ -118,6 +167,95 @@ public class UsageTrackingMiddlewareTests
                 expected,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    private static (DefaultHttpContext Context, RecyclableFeatureCollection Features) BuildRecyclableAuthenticatedContext(
+        string path, string query)
+    {
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature
+        {
+            Method = "GET",
+            Path = path,
+            QueryString = query,
+            Headers = new HeaderDictionary()
+        });
+        features.Set<IHttpResponseFeature>(new HttpResponseFeature
+        {
+            StatusCode = 200,
+            Headers = new HeaderDictionary()
+        });
+        features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(Stream.Null));
+        features.Set<IItemsFeature>(new ItemsFeature());
+
+        var recyclable = new RecyclableFeatureCollection(features);
+        var context = new DefaultHttpContext(recyclable);
+        context.Items["UserEmail"] = "test@marsvista.dev";
+        context.Items["UserTier"] = "free";
+        return (context, recyclable);
+    }
+
+    /// <summary>
+    /// An <see cref="IFeatureCollection"/> that throws <see cref="ObjectDisposedException"/>
+    /// once <see cref="Recycle"/> is called, mimicking how the server tears down the
+    /// request features after the response completes.
+    /// </summary>
+    private sealed class RecyclableFeatureCollection : IFeatureCollection
+    {
+        private readonly IFeatureCollection _inner;
+        private bool _recycled;
+
+        public RecyclableFeatureCollection(IFeatureCollection inner) => _inner = inner;
+
+        public void Recycle() => _recycled = true;
+
+        private void ThrowIfRecycled()
+        {
+            if (_recycled)
+            {
+                throw new ObjectDisposedException("Collection", "IFeatureCollection has been disposed.");
+            }
+        }
+
+        public object? this[Type key]
+        {
+            get { ThrowIfRecycled(); return _inner[key]; }
+            set { ThrowIfRecycled(); _inner[key] = value; }
+        }
+
+        public bool IsReadOnly
+        {
+            get { ThrowIfRecycled(); return _inner.IsReadOnly; }
+        }
+
+        public int Revision
+        {
+            get { ThrowIfRecycled(); return _inner.Revision; }
+        }
+
+        public TFeature? Get<TFeature>()
+        {
+            ThrowIfRecycled();
+            return _inner.Get<TFeature>();
+        }
+
+        public void Set<TFeature>(TFeature? instance)
+        {
+            ThrowIfRecycled();
+            _inner.Set(instance);
+        }
+
+        public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
+        {
+            ThrowIfRecycled();
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            ThrowIfRecycled();
+            return _inner.GetEnumerator();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes a recurring unobserved `ObjectDisposedException: IFeatureCollection has been disposed` thrown by `UsageTrackingMiddleware` — 39 events in production over ~7 months.

## Root cause

Usage events are persisted fire-and-forget. The detached task captured the `HttpContext` and read from it *after* awaiting `SaveChangesAsync`. Once the response completes, the framework recycles the context and its `IFeatureCollection`. When the database write failed, the catch handler logged `context.Request.Path` — dereferencing the now-disposed context — which threw a *second* `ObjectDisposedException`. That exception escaped the fire-and-forget task with no observer and surfaced on the finalizer thread (`UnobservedTaskException`).

The primary `SaveChangesAsync` failure was swallowed; the only thing reported was the secondary crash from the logging line.

## Fix

- Build the `UsageEvent` from the request/response **while the context is still alive**, then persist from that snapshot alone — the detached task no longer receives or touches the `HttpContext`.
- Resolve the `DbContext` from an injected `IServiceScopeFactory` (application-root singleton) instead of `context.RequestServices`, which is torn down with the response.
- Log failures using the captured endpoint string, so the catch handler cannot dereference a disposed context.

## Testing

- `dotnet build` — clean (0 errors).
- New `UsageTrackingMiddlewareTests` (3 tests, all pass): snapshot is built from the live request/response; anonymous requests are not tracked; a persistence failure is swallowed and logged without surfacing an exception.
- Confirmed the regression test has teeth: temporarily removing the try/catch guard makes the persistence-failure test fail (the exception surfaces from `InvokeAsync`), then restored the guard.

## Out of scope

The most recent Sentry error — `NullReferenceException` on `GET /api/v2/photos/{id}` — is a separate, single-occurrence framework race: MVC model binding ran `FormValueProviderFactory` on a connection the caller aborted mid-request, so `FormFeature` dereferenced a recycled `HttpContext.Features`. It is not application code and is not addressed here.
