### PR TITLE
Count photos_returned from the response body

### DIFF
--- a/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
+++ b/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
@@ -52,9 +52,14 @@ public class UsageTrackingMiddleware
 
             // Read error detail from response body before copying back
             string? errorDetail = null;
+            var photosReturned = 0;
             if (context.Response.StatusCode >= 400)
             {
                 errorDetail = ExtractErrorDetail(responseBody);
+            }
+            else if (context.Response.StatusCode < 300)
+            {
+                photosReturned = CountPhotosReturned(responseBody, context.Request.Path);
             }
 
             // Copy response back to original stream
@@ -67,7 +72,7 @@ public class UsageTrackingMiddleware
             // HttpContext: once the response completes the framework recycles the
             // context and its IFeatureCollection, so any later access throws
             // ObjectDisposedException on the unobserved task.
-            var usageEvent = BuildUsageEvent(context, stopwatch.ElapsedMilliseconds, errorDetail);
+            var usageEvent = BuildUsageEvent(context, stopwatch.ElapsedMilliseconds, errorDetail, photosReturned);
             if (usageEvent is not null)
             {
                 _ = TrackUsageAsync(usageEvent);
@@ -131,10 +136,79 @@ public class UsageTrackingMiddleware
     }
 
     /// <summary>
+    /// Counts the photos in a successful photo-endpoint response by inspecting
+    /// the buffered body. Derived centrally here - rather than set by each
+    /// controller - so every photo endpoint, v1 and v2, present and future, is
+    /// counted without per-endpoint wiring. Handles both response conventions:
+    /// v2 JSON:API ("data" array, or "data" object with type "photo") and v1
+    /// NASA-compatible ("photos" array, or "photo" object). Non-photo endpoints,
+    /// empty bodies, and unparseable bodies count 0.
+    /// </summary>
+    private static int CountPhotosReturned(MemoryStream responseBody, PathString path)
+    {
+        if (responseBody.Length == 0)
+        {
+            return 0;
+        }
+
+        // Only photo endpoints: /api/v*/photos*, /api/v1/rovers/{name}/photos,
+        // /api/v1/rovers/{name}/latest_photos. Excludes rovers/cameras/panoramas
+        // lists, whose v2 responses also carry a "data" array.
+        if (path.Value?.Contains("photos", StringComparison.OrdinalIgnoreCase) != true)
+        {
+            return 0;
+        }
+
+        try
+        {
+            responseBody.Seek(0, SeekOrigin.Begin);
+            using var doc = JsonDocument.Parse(responseBody);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return 0;
+            }
+
+            if (root.TryGetProperty("data", out var data))
+            {
+                if (data.ValueKind == JsonValueKind.Array)
+                {
+                    return data.GetArrayLength();
+                }
+
+                // A "data" object is a single photo only when typed as one -
+                // /photos/stats also returns a "data" object, of aggregates.
+                return data.ValueKind == JsonValueKind.Object
+                       && data.TryGetProperty("type", out var type)
+                       && type.ValueEquals("photo")
+                    ? 1
+                    : 0;
+            }
+
+            if (root.TryGetProperty("photos", out var photos) && photos.ValueKind == JsonValueKind.Array)
+            {
+                return photos.GetArrayLength();
+            }
+
+            if (root.TryGetProperty("photo", out var photo) && photo.ValueKind == JsonValueKind.Object)
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+        catch (JsonException)
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
     /// Builds the usage event from the request/response while the HttpContext is
     /// still alive. Returns null for unauthenticated requests (nothing to track).
     /// </summary>
-    private static UsageEvent? BuildUsageEvent(HttpContext context, long responseTimeMs, string? errorDetail)
+    private static UsageEvent? BuildUsageEvent(
+        HttpContext context, long responseTimeMs, string? errorDetail, int photosReturned)
     {
         // Extract user context (set by authentication middleware)
         var userEmail = context.Items["UserEmail"] as string;
@@ -145,11 +219,6 @@ public class UsageTrackingMiddleware
         }
 
         var userTier = context.Items["UserTier"] as string;
-
-        // Count photos returned (if applicable)
-        var photosReturned = context.Items.TryGetValue("PhotosReturned", out var value) && value is int count
-            ? count
-            : 0;
 
         // Capture query string for error requests
         var queryString = context.Request.QueryString.HasValue

--- a/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
+++ b/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
@@ -136,25 +136,20 @@ public class UsageTrackingMiddleware
     }
 
     /// <summary>
-    /// Counts the photos in a successful photo-endpoint response by inspecting
-    /// the buffered body. Derived centrally here - rather than set by each
-    /// controller - so every photo endpoint, v1 and v2, present and future, is
-    /// counted without per-endpoint wiring. Handles both response conventions:
-    /// v2 JSON:API ("data" array, or "data" object with type "photo") and v1
-    /// NASA-compatible ("photos" array, or "photo" object). Non-photo endpoints,
-    /// empty bodies, and unparseable bodies count 0.
+    /// Counts the photos in a successful response by inspecting the buffered
+    /// body. Derived centrally here - rather than set by each controller - so
+    /// every photo endpoint, v1 and v2, present and future, is counted without
+    /// per-endpoint wiring. Handles both response conventions: v1
+    /// NASA-compatible ("photos" array, or "photo" object - unambiguous keys,
+    /// matched on any path, which covers /rovers/{name}/latest alongside
+    /// /photos and /latest_photos) and v2 JSON:API ("data" array, or "data"
+    /// object with type "photo" - ambiguous key shared by rovers/cameras/
+    /// panoramas lists, so matched only under a photos path). Empty and
+    /// unparseable bodies count 0.
     /// </summary>
     private static int CountPhotosReturned(MemoryStream responseBody, PathString path)
     {
         if (responseBody.Length == 0)
-        {
-            return 0;
-        }
-
-        // Only photo endpoints: /api/v*/photos*, /api/v1/rovers/{name}/photos,
-        // /api/v1/rovers/{name}/latest_photos. Excludes rovers/cameras/panoramas
-        // lists, whose v2 responses also carry a "data" array.
-        if (path.Value?.Contains("photos", StringComparison.OrdinalIgnoreCase) != true)
         {
             return 0;
         }
@@ -169,7 +164,18 @@ public class UsageTrackingMiddleware
                 return 0;
             }
 
-            if (root.TryGetProperty("data", out var data))
+            if (root.TryGetProperty("photos", out var photos) && photos.ValueKind == JsonValueKind.Array)
+            {
+                return photos.GetArrayLength();
+            }
+
+            if (root.TryGetProperty("photo", out var photo) && photo.ValueKind == JsonValueKind.Object)
+            {
+                return 1;
+            }
+
+            if (path.Value?.Contains("photos", StringComparison.OrdinalIgnoreCase) == true
+                && root.TryGetProperty("data", out var data))
             {
                 if (data.ValueKind == JsonValueKind.Array)
                 {
@@ -185,20 +191,13 @@ public class UsageTrackingMiddleware
                     : 0;
             }
 
-            if (root.TryGetProperty("photos", out var photos) && photos.ValueKind == JsonValueKind.Array)
-            {
-                return photos.GetArrayLength();
-            }
-
-            if (root.TryGetProperty("photo", out var photo) && photo.ValueKind == JsonValueKind.Object)
-            {
-                return 1;
-            }
-
             return 0;
         }
-        catch (JsonException)
+        catch
         {
+            // Counting must never corrupt the response: an exception escaping
+            // here fires in InvokeAsync's finally before the buffered body is
+            // copied back to the client. Same posture as ExtractErrorDetail.
             return 0;
         }
     }

--- a/src/MarsVista.Api/Program.cs
+++ b/src/MarsVista.Api/Program.cs
@@ -476,7 +476,11 @@ app.UseMiddleware<ApiKeyMiddleware>();
 // User API key authentication (protects /api/v1/* public endpoints)
 app.UseMiddleware<UserApiKeyAuthenticationMiddleware>();
 
-// Usage tracking for admin dashboard analytics
+// Usage tracking for admin dashboard analytics. Must stay INSIDE (after)
+// UseResponseCompression: its body buffer captures controller output before
+// the outer compression stream runs, so error_detail/photos_returned parse
+// plaintext JSON. Registered before compression, it would buffer compressed
+// bytes and both would silently read as null/0.
 app.UseMiddleware<UsageTrackingMiddleware>();
 
 app.UseAuthorization();

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -130,6 +130,7 @@ public class UsageTrackingMiddlewareTests
     [Theory]
     [InlineData("""{"data":[{"id":1,"type":"photo"},{"id":2,"type":"photo"},{"id":3,"type":"photo"}],"meta":{"returned_count":3}}""", 3)]
     [InlineData("""{"data":[]}""", 0)]
+    [InlineData("""{"data":null}""", 0)]
     [InlineData("""{"data":{"id":42,"type":"photo","attributes":{}}}""", 1)]
     public async Task CountsPhotos_FromV2ResponseBody(string body, int expected)
     {
@@ -147,6 +148,31 @@ public class UsageTrackingMiddlewareTests
         var captured = await TrackRequest("/api/v1/rovers/curiosity/photos", body);
 
         captured!.PhotosReturned.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task V1LatestEndpoint_PathWithoutPhotosSegment_StillCountsPhotos()
+    {
+        // /api/v1/rovers/{name}/latest returns the same {"photos":[...]} shape
+        // as /photos and /latest_photos, but its path has no "photos" substring.
+        // The v1 root keys are unambiguous, so counting must not be path-gated.
+        var captured = await TrackRequest(
+            "/api/v1/rovers/curiosity/latest",
+            """{"photos":[{"id":1},{"id":2}],"pagination":{"page":1}}""");
+
+        captured!.PhotosReturned.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RatingEndpoint_FlatResponseOnPhotosPath_CountsZero()
+    {
+        // /api/v2/photos/{id}/rating lives under a photos path but returns a
+        // flat RatingResponse with no data/photos/photo root key.
+        var captured = await TrackRequest(
+            "/api/v2/photos/42/rating",
+            """{"average_rating":4.5,"rating_count":2,"user_rating":5}""");
+
+        captured!.PhotosReturned.Should().Be(0);
     }
 
     [Fact]

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -104,13 +104,12 @@ public class UsageTrackingMiddlewareTests
         UsageEvent? captured = null;
 
         var middleware = new TestableUsageTrackingMiddleware(
-            next: ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; },
+            next: WriteJsonResponse("""{"data":{"id":42,"type":"photo","attributes":{}}}"""),
             logger: Mock.Of<ILogger<UsageTrackingMiddleware>>(),
             persist: usageEvent => { captured = usageEvent; return Task.CompletedTask; });
 
         var context = BuildAuthenticatedContext(
             "/api/v2/photos/42", tier: "pro", query: "?include=rover,camera");
-        context.Items["PhotosReturned"] = 1;
 
         await middleware.InvokeAsync(context);
 
@@ -121,6 +120,80 @@ public class UsageTrackingMiddlewareTests
         captured.StatusCode.Should().Be(200);
         captured.QueryString.Should().Be("?include=rover,camera");
         captured.PhotosReturned.Should().Be(1);
+    }
+
+    // photos_returned is derived centrally from the buffered response body, not
+    // set by controllers: nothing ever wrote HttpContext.Items["PhotosReturned"],
+    // so every production row carried 0. These tests pin the counting rules for
+    // each real response shape (v2 JSON:API, v1 NASA-compatible).
+
+    [Theory]
+    [InlineData("""{"data":[{"id":1,"type":"photo"},{"id":2,"type":"photo"},{"id":3,"type":"photo"}],"meta":{"returned_count":3}}""", 3)]
+    [InlineData("""{"data":[]}""", 0)]
+    [InlineData("""{"data":{"id":42,"type":"photo","attributes":{}}}""", 1)]
+    public async Task CountsPhotos_FromV2ResponseBody(string body, int expected)
+    {
+        var captured = await TrackRequest("/api/v2/photos", body);
+
+        captured!.PhotosReturned.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("""{"photos":[{"id":1},{"id":2}]}""", 2)]
+    [InlineData("""{"photos":[]}""", 0)]
+    [InlineData("""{"photo":{"id":42}}""", 1)]
+    public async Task CountsPhotos_FromV1ResponseBody(string body, int expected)
+    {
+        var captured = await TrackRequest("/api/v1/rovers/curiosity/photos", body);
+
+        captured!.PhotosReturned.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task StatsResponse_DataObjectWithoutPhotoType_CountsZero()
+    {
+        var captured = await TrackRequest(
+            "/api/v2/photos/stats",
+            """{"data":{"total_photos":571,"groups":[{"key":"MAST","count":553}]}}""");
+
+        captured!.PhotosReturned.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NonPhotoEndpoint_WithDataArray_CountsZero()
+    {
+        var captured = await TrackRequest(
+            "/api/v2/rovers",
+            """{"data":[{"id":1,"type":"rover"},{"id":2,"type":"rover"}]}""");
+
+        captured!.PhotosReturned.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ErrorResponse_CountsZero()
+    {
+        var captured = await TrackRequest(
+            "/api/v2/photos",
+            """{"detail":"Validation Error","errors":[{"message":"bad sol"}]}""",
+            statusCode: 400);
+
+        captured!.PhotosReturned.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EmptyBody_NotModifiedResponse_CountsZero()
+    {
+        var captured = await TrackRequest("/api/v2/photos", body: null, statusCode: 304);
+
+        captured!.PhotosReturned.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MalformedJsonBody_CountsZero_WithoutThrowing()
+    {
+        var captured = await TrackRequest("/api/v2/photos", "not json {");
+
+        captured!.PhotosReturned.Should().Be(0);
     }
 
     [Fact]
@@ -140,6 +213,40 @@ public class UsageTrackingMiddlewareTests
         await middleware.InvokeAsync(context);
 
         persisted.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A pipeline terminal that writes <paramref name="json"/> as the response
+    /// body, mimicking a controller result the middleware must count from.
+    /// </summary>
+    private static RequestDelegate WriteJsonResponse(string json, int statusCode = 200) =>
+        async ctx =>
+        {
+            ctx.Response.StatusCode = statusCode;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(json);
+        };
+
+    /// <summary>
+    /// Runs one authenticated request through the middleware with the given
+    /// response body and returns the captured usage event.
+    /// </summary>
+    private static async Task<UsageEvent?> TrackRequest(
+        string path, string? body, int statusCode = 200)
+    {
+        UsageEvent? captured = null;
+
+        var middleware = new TestableUsageTrackingMiddleware(
+            next: body is null
+                ? ctx => { ctx.Response.StatusCode = statusCode; return Task.CompletedTask; }
+                : WriteJsonResponse(body, statusCode),
+            logger: Mock.Of<ILogger<UsageTrackingMiddleware>>(),
+            persist: usageEvent => { captured = usageEvent; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(BuildAuthenticatedContext(path));
+
+        captured.Should().NotBeNull();
+        return captured;
     }
 
     private static DefaultHttpContext BuildAuthenticatedContext(


### PR DESCRIPTION
## Problem

`usage_events.photos_returned` has been 0 for every request since the column was added. The tracking middleware read `HttpContext.Items["PhotosReturned"]`, but no production code ever wrote that key — only the middleware's own unit test did, which is why its tests stayed green while production recorded zeros. Every row in the admin activity view shows 0, and the monthly rollup's `total_photos_returned` has been aggregating zeros.

## Fix

Count photos centrally in `UsageTrackingMiddleware`, from the response body it already buffers for error extraction, on successful (2xx) responses:

- v1 NASA-compatible: `photos` array → its length; `photo` object → 1. These root keys are unambiguous (verified by a route sweep: no non-photo endpoint emits them), so they're matched on **any** path — covering `/rovers/{name}/photos`, `/latest_photos`, **and `/rovers/{name}/latest`**, whose path contains no "photos" substring.
- v2 JSON:API: `data` array → its length; `data` object typed `"photo"` → 1 (a `data` object *without* that type, e.g. `/photos/stats`, counts 0). The `data` key is shared by rovers/cameras/panoramas list responses, so it's only counted under a photos path.
- Empty bodies (304/204), 3xx/4xx/5xx, flat shapes (e.g. `/photos/{id}/rating`), and unparseable JSON count 0.

## Why derive from the body instead of setting it per controller

The alternative — writing `Items["PhotosReturned"]` in each of the 7+ photo actions — recreates the original failure mode: the next endpoint that forgets the write silently records 0 again, and nothing in the test suite hosts controllers and middleware together to catch the missed wiring. Counting from the buffered body keeps the concern in one file, covers v1, v2, and future photo endpoints, and reports what was actually sent. The parse cost lands only on 2xx responses whose bodies are already in memory.

## Review notes (independent code review, isolated worktree)

- **Compression ordering verified safe:** `UseResponseCompression` registers *outer* to this middleware, so the buffer captures plaintext before compression — confirmed empirically with a live two-middleware pipeline probe (gzip round-trip byte-identical, count correct). A comment in `Program.cs` now pins this ordering dependency.
- **Review finding fixed:** `/api/v1/rovers/{name}/latest` was excluded by the original path gate (its path lacks "photos") — the v1 keys are now matched shape-first on any path, with a pinning test.
- Counting `catch` widened to match `ExtractErrorDetail`: an exception escaping in the `finally` would corrupt the client response — disproportionate blast radius for a telemetry counter.
- Full endpoint-shape sweep (v1 + v2 including batch, stats, ratings) verified against code and live production responses.

## Testing

- Middleware tests cover every real response shape: v2 list/single/stats/batch, v1 list/latest_photos/latest/single, rating endpoints' flat shape on a photos path, non-photo endpoints with a `data` array, 400s, 304s, `data:null`, malformed JSON.
- The non-zero cases fail without the fix; the `/latest` case fails without the second commit.
- Full suite: 489 tests pass.
