### PR TITLE
Default-sort single-rover photo queries sol-first

### DIFF
--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -642,13 +642,38 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
     }
 
     /// <summary>
+    /// True when the query's rover filter resolves to exactly one rover, which
+    /// is what makes the sol-first default sort equivalent to date order.
+    /// </summary>
+    private bool IsSingleRoverQuery(PhotoQueryParameters parameters) =>
+        parameters.RoverList.Count > 0
+        && _referenceCache.GetRoverIdsByNames(parameters.RoverList).Count == 1;
+
+    /// <summary>
     /// Apply sorting to the query
     /// </summary>
     private IQueryable<Photo> ApplySorting(IQueryable<Photo> query, PhotoQueryParameters parameters)
     {
         if (parameters.SortFields.Count == 0)
         {
-            // Default sort: most recent first
+            // Default sort: most recent first. For a single-rover query this is
+            // expressed sol-first: within one rover, sol order IS date order (a
+            // sol is one Mars day, so sol N+1 photos are always taken after
+            // sol N), but sol-first lets the planner serve wide sol-range
+            // queries from ix_photos_rover_id_camera_id_sol with an incremental
+            // sort (12 ms measured) instead of backward-scanning
+            // ix_photos_date_taken_utc past every newer photo of every rover
+            // (~1.2M rows discarded, 4-5 s warm / 95 s cold measured).
+            // Across rovers sols are not comparable (Spirit sol 1 is 2004,
+            // Curiosity sol 1 is 2012), so multi-rover queries keep the
+            // date-only sort.
+            if (IsSingleRoverQuery(parameters))
+            {
+                return query
+                    .OrderByDescending(p => p.Sol)
+                    .ThenByDescending(p => p.DateTakenUtc);
+            }
+
             return query.OrderByDescending(p => p.DateTakenUtc);
         }
 

--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -421,6 +421,10 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         // the planner to backward-scan ix_photos_sol (4 GB of buffer reads per call).
         // Scalar = is also critical for the single-rover case (the planner does not
         // use ix_photos_rover_id_sol_covering when it sees `rover_id = ANY(ARRAY[x])`).
+        // NOTE: IsSingleRoverQuery repeats this resolution to pick the default sort;
+        // the sol-first sort is only valid when this filter matches exactly one
+        // rover, so any change to how rover ids are resolved here must be
+        // mirrored there.
         if (parameters.RoverList.Count > 0)
         {
             var roverIds = _referenceCache.GetRoverIdsByNames(parameters.RoverList);
@@ -643,7 +647,10 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
 
     /// <summary>
     /// True when the query's rover filter resolves to exactly one rover, which
-    /// is what makes the sol-first default sort equivalent to date order.
+    /// is what makes the sol-first default sort equivalent to date order. Must
+    /// stay consistent with BuildQuery's rover filter: both resolve the same
+    /// RoverList through the same cache, so within a request they cannot
+    /// disagree - a change to either resolution must be mirrored in the other.
     /// </summary>
     private bool IsSingleRoverQuery(PhotoQueryParameters parameters) =>
         parameters.RoverList.Count > 0

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -246,6 +246,85 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task SingleRoverDefaultSort_SolWinsOverDiscordantDate()
+    {
+        // Pins the one deliberate semantic choice of the sol-first rewrite:
+        // when sol and date disagree (17 early-Perseverance sol boundaries in
+        // production have date_taken_utc overlapping the neighbouring sol by up
+        // to 17 days - NASA data quirks), the default order follows sol, i.e.
+        // NASA's mission attribution, not the unreliable timestamp. Under the
+        // old date-only sort these two photos would come back reversed.
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "DIS-SOL-WINS", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 2100, EarthDate = new DateTime(2013, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2013, 6, 1, 10, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "DIS-DATE-LOSES", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 2000, EarthDate = new DateTime(2015, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 6, 1, 10, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            });
+        await DbContext.SaveChangesAsync();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            SolMin = 2000, SolMax = 2200,
+            Page = 1, PerPage = 10,
+        };
+
+        var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        response.Data.Select(p => p.Attributes!.NasaId).Should().Equal(
+            "DIS-SOL-WINS", "DIS-DATE-LOSES");
+    }
+
+    [Fact]
+    public async Task SingleRoverMultiCameraFilter_KeepsSolFirstDefaultSort()
+    {
+        SqlCapture.Clear();
+
+        // FHAZ resolves to two camera ids (duplicate name across rovers) and
+        // MAST to one, so the camera predicate is a multi-id ANY/IN - the sort
+        // decision must still be sol-first because it depends only on the
+        // rover filter resolving to a single rover.
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            Cameras = "FHAZ,MAST",
+            CameraList = new List<string> { "FHAZ", "MAST" },
+            Page = 1, PerPage = 10,
+        };
+
+        await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        var dataSql = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        dataSql.Should().NotBeEmpty();
+        foreach (var sql in dataSql)
+        {
+            sql.Should().Contain("camera_id");
+            (sql.Contains("= ANY (") || sql.Contains("camera_id IN ("))
+                .Should().BeTrue("multi-id camera filter must keep all camera ids");
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?date_taken_utc""?\s+DESC",
+                "a multi-camera filter must not flip the single-rover sol-first sort");
+        }
+    }
+
+    [Fact]
     public async Task MultiRoverFilter_EmitsAnyArrayOnRoverId()
     {
         SqlCapture.Clear();

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -99,6 +99,153 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task SingleRoverDefaultSort_OrdersBySolThenDate()
+    {
+        SqlCapture.Clear();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            SolMin = 1, SolMax = 1000,
+            Page = 1, PerPage = 10,
+        };
+
+        await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        // The default "most recent first" sort must be expressed sol-first for a
+        // single-rover query so the planner serves it from
+        // ix_photos_rover_id_camera_id_sol / ix_photos_rover_id_sol_covering with
+        // an incremental sort, instead of backward-scanning ix_photos_date_taken_utc
+        // past every newer photo of every rover (~1.2M rows discarded, 4-5s per
+        // request in production for wide sol ranges).
+        var dataSql = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        dataSql.Should().NotBeEmpty("the paginated data query must be ordered");
+        foreach (var sql in dataSql)
+        {
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?date_taken_utc""?\s+DESC",
+                "single-rover default sort must be sol DESC, date_taken_utc DESC");
+        }
+    }
+
+    [Fact]
+    public async Task MultiRoverDefaultSort_OrdersByDateAlone()
+    {
+        SqlCapture.Clear();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity,perseverance",
+            RoverList = new List<string> { "curiosity", "perseverance" },
+            Page = 1, PerPage = 10,
+        };
+
+        await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        // Across rovers, sol numbers are not comparable (Spirit sol 1 is 2004,
+        // Curiosity sol 1 is 2012), so the multi-rover default sort must stay
+        // date-only.
+        var dataSql = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        dataSql.Should().NotBeEmpty();
+        foreach (var sql in dataSql)
+        {
+            sql.Should().NotMatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?",
+                "multi-rover queries must not sort by sol - sols are not comparable across rovers");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverExplicitDateSort_KeepsDateOnlyOrder()
+    {
+        SqlCapture.Clear();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            // The validator normally parses Sort into SortFields before the
+            // service runs; the service only reads SortFields.
+            Sort = "-date_taken_utc",
+            SortFields = new List<SortField>
+            {
+                new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
+            },
+            Page = 1, PerPage = 10,
+        };
+
+        await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        // An explicit sort is the caller's contract; only the default sort is
+        // rewritten to the sol-first equivalent.
+        var dataSql = SqlCapture.ExecutedSql
+            .Where(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        dataSql.Should().NotBeEmpty();
+        foreach (var sql in dataSql)
+        {
+            sql.Should().NotMatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?",
+                "explicit sort=-date_taken_utc must be honoured as given");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverDefaultSort_ReturnsPhotosMostRecentFirst()
+    {
+        // Three curiosity photos out of sol order in the table; the default sort
+        // must return them newest-first regardless of how it is expressed in SQL.
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "ORD-MID", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 500, EarthDate = new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2014, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "ORD-NEW", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 900, EarthDate = new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 2, 1, 8, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "ORD-OLD", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 100, EarthDate = new DateTime(2013, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2013, 3, 1, 9, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            });
+        await DbContext.SaveChangesAsync();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            SolMin = 50, SolMax = 950,
+            Page = 1, PerPage = 10,
+        };
+
+        var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        response.Data.Select(p => p.Attributes!.NasaId).Should().ContainInOrder(
+            "ORD-NEW", "ORD-MID", "ORD-OLD");
+    }
+
+    [Fact]
     public async Task MultiRoverFilter_EmitsAnyArrayOnRoverId()
     {
         SqlCapture.Clear();


### PR DESCRIPTION
## Problem

`GET /api/v2/photos?rovers=curiosity&sol_min=1&sol_max=1000&cameras=MAST&per_page=10` took **4–5 s warm, 95 s cold**. `EXPLAIN ANALYZE` on production showed the planner backward-scanning `ix_photos_date_taken_utc` for the default `ORDER BY date_taken_utc DESC LIMIT 10`, discarding **1,192,616 rows** before finding 10 matches. The planner assumes qualifying rows are spread evenly through the date index; a wide sol range on one rover actually clusters at the old end, behind every newer photo of every rover. A pro user's photo-browser UI hitting this shape at ~1 req/s was what surfaced it.

## Fix

Within one rover, sol order **is** date order (a sol is one Mars day; sol N+1 photos are always taken after sol N). When the rover filter resolves to exactly one rover and no explicit `?sort=` is given, the default sort is now expressed as `ORDER BY sol DESC, date_taken_utc DESC`, which the planner serves from the existing `ix_photos_rover_id_camera_id_sol` / `ix_photos_rover_id_sol_covering` indexes with an incremental sort.

Measured on production for the query above:

| | plan | rows read | time |
|---|---|---|---|
| before | backward scan of `ix_photos_date_taken_utc` | 1.19M discarded | 4–5 s warm / 95 s cold |
| after | index scan + incremental sort | 554 | **12 ms** |

Multi-rover and unfiltered queries keep the date-only sort (sols aren't comparable across rovers: Spirit sol 1 is 2004, Curiosity sol 1 is 2012). Explicit `?sort=` is honoured as given. No new index required.

## Behavioural nuance

17 early-Perseverance sol boundaries (sols 0–186, 2021) have `date_taken_utc` values overlapping the neighbouring sol by minutes up to 17 days (NASA data quirks; verified zero violations for Curiosity/Opportunity/Spirit). For those anomalous rows the sol-first order differs from strict date order. Sol order matches NASA's mission attribution, and the timestamps there are unreliable — still "most recent first" to the fidelity the data supports. This choice is now pinned by a discordant-pair test.

## Review notes (independent code review, isolated worktree)

Verdict: approve, no blockers. Follow-ups applied in the second commit:

- **Discordant-pair test added** — the original ordering test used concordant data and couldn't distinguish the new order from the old; the accepted sol-over-date behaviour is now executable.
- **Multi-camera shape test added** — a `= ANY(ARRAY[...])` camera filter must not flip the single-rover sol-first sort (the decision reads only the rover list).
- **Coupling documented** — `BuildQuery`'s rover filter and `IsSingleRoverQuery`'s sort decision resolve the same list through the same cache and must stay mirrored; both sites now cross-reference each other. The reviewer confirmed the dangerous inversion (sol-first sort while the filter matches multiple rovers) is unreachable today, including for duplicate names, unknown names, and case variants.
- Reviewer also confirmed: blast radius is exactly the v2 list endpoint (single `ApplySorting` caller); the count cache keys on the unsorted query so caching is unaffected; `sol` is non-nullable so no NULLS FIRST surprise; tie non-determinism at page boundaries is pre-existing and strictly narrower under the new ordering.

## Testing

- SQL-shape tests (via `SqlCapturingInterceptor`, per the 052a pattern): single-rover default sort emits `sol DESC, date_taken_utc DESC`; multi-rover stays date-only; explicit `sort=-date_taken_utc` honoured; multi-camera ANY-array keeps sol-first; plus ordering-correctness tests (newest-first, and sol-wins-over-discordant-date).
- The sol-first shape test fails without the fix; the discordant-pair test fails under the old ordering.
- Full suite: 481 tests pass.

## Known follow-up (different repo)

`mars-vista-web/landing/app/docs/troubleshooting/page.tsx` claims the default sort is "by earth_date descending" — already wrong before this PR (actual default was `date_taken_utc`). Needs a docs fix in that repo.
