### PR TITLE
Raise local Postgres shm_size to 256MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --shm-size 256mb
 
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-marsvista_dev}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
+    # Docker's default /dev/shm is 64MB; the parallel integration-test suite
+    # (one database per test class, concurrent parallel workers) can exhaust it,
+    # crashing the backend with "53100: could not resize shared memory segment"
+    # followed by minutes of crash recovery.
+    shm_size: 256mb
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
Docker's default 64MB `/dev/shm` is too small for the parallel integration-test suite: each test class creates its own `marsvista_test_<guid>` database and xunit runs classes concurrently. A full run can exhaust the segment, crashing the backend with `53100: could not resize shared memory segment` followed by ~150 cascaded `57P03 recovery mode` failures and several minutes of crash recovery (observed during an isolated-worktree review run of the full suite).

Second commit (from review): the GitHub Actions Postgres service container has the same 64MB default, so CI gets the matching `--shm-size 256mb` — lower odds there (4-way xunit parallelism on the hosted runner vs 20 locally), but it closes the same failure class. Also drops the obsolete compose `version` key that warns on every invocation under Compose v2.

**Note (from review):** the setting only applies when the container is recreated — the currently running `marsvista-postgres` is still at 64MB (verified via `docker inspect`). After merging, run `docker compose up -d` once; the `postgres_data` volume persists, so no data is lost.

Local development only as far as the compose file goes — the production database is on Railway and unaffected.
