### PR TITLE
Pin photo counting for panorama detail responses

### DIFF
--- a/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
+++ b/src/MarsVista.Api/Middleware/UsageTrackingMiddleware.cs
@@ -139,13 +139,14 @@ public class UsageTrackingMiddleware
     /// Counts the photos in a successful response by inspecting the buffered
     /// body. Derived centrally here - rather than set by each controller - so
     /// every photo endpoint, v1 and v2, present and future, is counted without
-    /// per-endpoint wiring. Handles both response conventions: v1
-    /// NASA-compatible ("photos" array, or "photo" object - unambiguous keys,
-    /// matched on any path, which covers /rovers/{name}/latest alongside
-    /// /photos and /latest_photos) and v2 JSON:API ("data" array, or "data"
-    /// object with type "photo" - ambiguous key shared by rovers/cameras/
-    /// panoramas lists, so matched only under a photos path). Empty and
-    /// unparseable bodies count 0.
+    /// per-endpoint wiring. Handles both response conventions: root "photos"
+    /// array or "photo" object (v1 endpoints including /rovers/{name}/latest,
+    /// and the v2 panorama detail, whose unwrapped resource carries its member
+    /// photos as a root "photos" array - those are real photo payloads and are
+    /// deliberately counted), matched on any path; and v2 JSON:API ("data"
+    /// array, or "data" object with type "photo" - ambiguous key shared by
+    /// rovers/cameras/panoramas lists, so matched only under a photos path).
+    /// Empty and unparseable bodies count 0.
     /// </summary>
     private static int CountPhotosReturned(MemoryStream responseBody, PathString path)
     {

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -190,6 +190,18 @@ public class UsageTrackingMiddlewareTests
     }
 
     [Fact]
+    public async Task PanoramaList_DataWrapperWithoutRootPhotos_CountsZero()
+    {
+        // The panoramas LIST wraps panoramas in a "data" array and omits their
+        // photos entirely (Photos is null and JsonIgnored), so nothing counts.
+        var captured = await TrackRequest(
+            "/api/v2/panoramas",
+            """{"data":[{"id":"pano_curiosity_4919_1","type":"panorama","attributes":{"total_photos":6}}],"meta":{}}""");
+
+        captured!.PhotosReturned.Should().Be(0);
+    }
+
+    [Fact]
     public async Task StatsResponse_DataObjectWithoutPhotoType_CountsZero()
     {
         var captured = await TrackRequest(

--- a/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
+++ b/tests/MarsVista.Api.Tests/Middleware/UsageTrackingMiddlewareTests.cs
@@ -176,6 +176,20 @@ public class UsageTrackingMiddlewareTests
     }
 
     [Fact]
+    public async Task PanoramaDetail_WithRootPhotosArray_CountsMemberPhotos()
+    {
+        // /api/v2/panoramas/{id} embeds the panorama's member photos as a root
+        // "photos" array (no "data" wrapper - verified against production).
+        // Those are real photo payloads served to the caller, so they count;
+        // the panoramas LIST response has no root "photos" key and counts 0.
+        var captured = await TrackRequest(
+            "/api/v2/panoramas/pano_curiosity_4919_1",
+            """{"id":"pano_curiosity_4919_1","type":"panorama","attributes":{"total_photos":2},"photos":[{"id":1},{"id":2}],"links":{}}""");
+
+        captured!.PhotosReturned.Should().Be(2);
+    }
+
+    [Fact]
     public async Task StatsResponse_DataObjectWithoutPhotoType_CountsZero()
     {
         var captured = await TrackRequest(


### PR DESCRIPTION
Production verification after #28 deployed showed `/api/v2/panoramas/{id}` recording `photos_returned = 6`: that response embeds the panorama's member photos as a **root** `photos` array with no `data` wrapper, so the un-path-gated v1-key check counts them. The route sweep during #28's review missed this shape.

Assessment: the behaviour is truthful — the detail response delivers real, full photo payloads (extended fieldset with rover/camera includes), so counting them is more accurate than 0, and consistent: the same photos fetched via `/photos/batch` would count. The panoramas *list* omits photos entirely (`Photos` is null and JsonIgnored, wrapped in `data`) and correctly records 0. This PR pins both sides with characterization tests.

## Review notes (independent code review, isolated worktree)

- Reviewer confirmed fidelity against the real DTOs: `PanoramaResource` root keys are exactly `id/type/attributes/photos/links`, the detail action returns the resource unwrapped, and the list maps without photos.
- Reviewer's full sweep of every response shape in both API versions confirmed **panorama detail is the only non-photo endpoint** the root-`photos` branch catches (manifests, journey, traverse GeoJSON, locations, ratings, API root are all safe).
- Follow-ups applied from review: the middleware doc comment called the root keys "unambiguous v1 conventions", which this pin falsifies — restated as shape-based with the panorama case named explicitly; and the panoramas-list "counts 0" claim, previously prose-only, is now a test.
- Latent-risk note from the sweep: `LocationsController` is the other endpoint returning an unwrapped root resource — if a future feature adds a root `photos` array there, repeat this pin pattern.

No production behaviour changes (comment-only in src).
