### PR TITLE
Extend the sol prefix to explicit date-family sorts

### DIFF
--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -647,10 +647,12 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
 
     /// <summary>
     /// True when the query's rover filter resolves to exactly one rover, which
-    /// is what makes the sol-first default sort equivalent to date order. Must
-    /// stay consistent with BuildQuery's rover filter: both resolve the same
-    /// RoverList through the same cache, so within a request they cannot
-    /// disagree - a change to either resolution must be mirrored in the other.
+    /// is what makes sol order equivalent to date order - the precondition for
+    /// both the sol-first default sort and the explicit-sort sol prefix
+    /// (ShouldPrefixSolToExplicitSort). Must stay consistent with BuildQuery's
+    /// rover filter: both resolve the same RoverList through the same cache,
+    /// so within a request they cannot disagree - a change to either
+    /// resolution must be mirrored in the other.
     /// </summary>
     private bool IsSingleRoverQuery(PhotoQueryParameters parameters) =>
         parameters.RoverList.Count > 0
@@ -672,10 +674,13 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
     /// intact except for 27 (rover, timestamp) groups that span two sols.
     ///
     /// A lone earth_date sort: order-preserving on all current data - zero
-    /// sol/earth_date ordering violations on any rover (legacy rows carry
-    /// NASA's sol-aligned attribution; rows from the current scrapers derive
-    /// earth_date from date_taken_utc). That invariant is empirical, not
-    /// structural, so the daily scrape tripwires it (EarthDateMonotonicityCheck).
+    /// sol/earth_date ordering violations AND zero NULL earth_dates on any
+    /// rover (legacy rows carry NASA's sol-aligned attribution; rows from the
+    /// current scrapers derive earth_date from date_taken_utc). Both
+    /// preconditions matter: a NULL row sorts NULLS-first under a plain
+    /// earth_date DESC but inside its sol group under the prefixed sort. The
+    /// invariant is empirical, not structural, so the daily scrape tripwires
+    /// both counts (EarthDateMonotonicityCheck).
     ///
     /// earth_date with an explicit tiebreak is excluded: a sol spans two Earth
     /// dates, so adjacent sols share earth_dates and the prefix would override

--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -421,10 +421,10 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         // the planner to backward-scan ix_photos_sol (4 GB of buffer reads per call).
         // Scalar = is also critical for the single-rover case (the planner does not
         // use ix_photos_rover_id_sol_covering when it sees `rover_id = ANY(ARRAY[x])`).
-        // NOTE: IsSingleRoverQuery repeats this resolution to pick the default sort;
-        // the sol-first sort is only valid when this filter matches exactly one
-        // rover, so any change to how rover ids are resolved here must be
-        // mirrored there.
+        // NOTE: IsSingleRoverQuery repeats this resolution to gate the sol-first
+        // default sort AND the explicit-sort sol prefix; both are only valid
+        // when this filter matches exactly one rover, so any change to how
+        // rover ids are resolved here must be mirrored there.
         if (parameters.RoverList.Count > 0)
         {
             var roverIds = _referenceCache.GetRoverIdsByNames(parameters.RoverList);
@@ -657,18 +657,33 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         && _referenceCache.GetRoverIdsByNames(parameters.RoverList).Count == 1;
 
     /// <summary>
-    /// True when prefixing sol to the requested sort can only refine ties the
-    /// caller left unspecified, never reorder what they asked for. Holds for
-    /// date_taken_utc-first sorts (within one rover, sol order is timestamp
-    /// order; identical timestamps spanning two sols are a 27-in-1.5M data
-    /// quirk) and for a lone earth_date sort (earth_date is exactly
-    /// sol-monotone in the data - it derives from NASA's per-sol attribution).
+    /// True when a single-rover query's explicit sort should be served with a
+    /// sol prefix. The two included cases rest on different arguments:
+    ///
+    /// date_taken_utc-first sorts (any tail): within one rover, sol order is
+    /// timestamp order EXCEPT at 17 early-Perseverance sol boundaries whose
+    /// timestamps overlap the neighbouring sol (NASA data errors, up to 17
+    /// days adrift) - there the prefix genuinely inverts the literal request.
+    /// Accepted trade-off, same as DECISION-023 made for the default sort:
+    /// those timestamps are unreliable, sol order matches NASA's mission
+    /// attribution, and default and explicit timestamp sorts stay identical.
+    /// It does mean strict raw-timestamp order across those boundaries is not
+    /// obtainable for a single-rover query. An explicit tail is preserved
+    /// intact except for 27 (rover, timestamp) groups that span two sols.
+    ///
+    /// A lone earth_date sort: order-preserving on all current data - zero
+    /// sol/earth_date ordering violations on any rover (legacy rows carry
+    /// NASA's sol-aligned attribution; rows from the current scrapers derive
+    /// earth_date from date_taken_utc). That invariant is empirical, not
+    /// structural, so the daily scrape tripwires it (EarthDateMonotonicityCheck).
+    ///
     /// earth_date with an explicit tiebreak is excluded: a sol spans two Earth
     /// dates, so adjacent sols share earth_dates and the prefix would override
     /// the caller's tiebreak for same-date photos.
     /// </summary>
-    private static bool SolPrefixPreservesRequestedOrder(List<SortField> sortFields) =>
-        sortFields[0].Field switch
+    private static bool ShouldPrefixSolToExplicitSort(List<SortField> sortFields) =>
+        sortFields.Count > 0
+        && sortFields[0].Field switch
         {
             "date_taken_utc" => true,
             "earth_date" => sortFields.Count == 1,
@@ -713,7 +728,7 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         // measured); with the sol prefix the covering index satisfies the
         // ORDER BY outright (0.13 ms measured). Seeding orderedQuery here
         // makes the loop below append every requested field unchanged.
-        if (IsSingleRoverQuery(parameters) && SolPrefixPreservesRequestedOrder(parameters.SortFields))
+        if (IsSingleRoverQuery(parameters) && ShouldPrefixSolToExplicitSort(parameters.SortFields))
         {
             orderedQuery = parameters.SortFields[0].Direction == SortDirection.Descending
                 ? query.OrderByDescending(p => p.Sol)

--- a/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
+++ b/src/MarsVista.Api/Services/V2/PhotoQueryServiceV2.cs
@@ -657,6 +657,25 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         && _referenceCache.GetRoverIdsByNames(parameters.RoverList).Count == 1;
 
     /// <summary>
+    /// True when prefixing sol to the requested sort can only refine ties the
+    /// caller left unspecified, never reorder what they asked for. Holds for
+    /// date_taken_utc-first sorts (within one rover, sol order is timestamp
+    /// order; identical timestamps spanning two sols are a 27-in-1.5M data
+    /// quirk) and for a lone earth_date sort (earth_date is exactly
+    /// sol-monotone in the data - it derives from NASA's per-sol attribution).
+    /// earth_date with an explicit tiebreak is excluded: a sol spans two Earth
+    /// dates, so adjacent sols share earth_dates and the prefix would override
+    /// the caller's tiebreak for same-date photos.
+    /// </summary>
+    private static bool SolPrefixPreservesRequestedOrder(List<SortField> sortFields) =>
+        sortFields[0].Field switch
+        {
+            "date_taken_utc" => true,
+            "earth_date" => sortFields.Count == 1,
+            _ => false,
+        };
+
+    /// <summary>
     /// Apply sorting to the query
     /// </summary>
     private IQueryable<Photo> ApplySorting(IQueryable<Photo> query, PhotoQueryParameters parameters)
@@ -685,6 +704,21 @@ public class PhotoQueryServiceV2 : IPhotoQueryServiceV2
         }
 
         IOrderedQueryable<Photo>? orderedQuery = null;
+
+        // Explicit date-family sorts get the same sol prefix as the default
+        // sort, in the requested direction, when the prefix cannot change the
+        // order the caller observes. Same planner pathology, same cure:
+        // explicit -earth_date over a wide sol range backward-scanned
+        // ix_photos_rover_id_earth_date discarding 639K rows (2,010 ms
+        // measured); with the sol prefix the covering index satisfies the
+        // ORDER BY outright (0.13 ms measured). Seeding orderedQuery here
+        // makes the loop below append every requested field unchanged.
+        if (IsSingleRoverQuery(parameters) && SolPrefixPreservesRequestedOrder(parameters.SortFields))
+        {
+            orderedQuery = parameters.SortFields[0].Direction == SortDirection.Descending
+                ? query.OrderByDescending(p => p.Sol)
+                : query.OrderBy(p => p.Sol);
+        }
 
         foreach (var sortField in parameters.SortFields)
         {

--- a/src/MarsVista.Core/Services/EarthDateMonotonicityCheck.cs
+++ b/src/MarsVista.Core/Services/EarthDateMonotonicityCheck.cs
@@ -14,19 +14,28 @@ namespace MarsVista.Core.Services;
 /// crossing UTC midnight would break the invariant silently. The daily scrape
 /// runs this check so a break is loud instead.
 /// </summary>
+/// <summary>
+/// Result of the invariant check. <paramref name="OrderingViolations"/> counts
+/// consecutive-sol pairs (per rover) where the earlier sol's latest earth_date
+/// exceeds the later sol's earliest. <paramref name="NullEarthDates"/> counts
+/// photos with no earth_date at all - counted separately because SQL NULL
+/// comparisons silently drop out of the ordering check, so NULLs would
+/// otherwise blind it (an all-NULL sol even masks a real violation across it).
+/// The invariant holds only when both are zero.
+/// </summary>
+public record EarthDateInvariantResult(int OrderingViolations, int NullEarthDates);
+
 public interface IEarthDateMonotonicityCheck
 {
     /// <summary>
-    /// Counts pairs of consecutive sols (per rover) where the earlier sol's
-    /// latest earth_date exceeds the later sol's earliest. Zero means the
-    /// invariant holds.
+    /// Checks the sol/earth_date ordering invariant across all photos.
     /// </summary>
-    Task<int> CountViolationsAsync(CancellationToken cancellationToken = default);
+    Task<EarthDateInvariantResult> CheckAsync(CancellationToken cancellationToken = default);
 }
 
 public class EarthDateMonotonicityCheck : IEarthDateMonotonicityCheck
 {
-    private const string ViolationCountSql = @"
+    private const string InvariantCheckSql = @"
 WITH per_sol AS (
     SELECT rover_id, sol, MIN(earth_date) AS min_date, MAX(earth_date) AS max_date
     FROM photos
@@ -37,10 +46,13 @@ paired AS (
            LEAD(min_date) OVER (PARTITION BY rover_id ORDER BY sol) AS next_sol_min_date
     FROM per_sol
 )
-SELECT COUNT(*) FROM paired WHERE max_date > next_sol_min_date";
+SELECT
+    (SELECT COUNT(*) FROM paired WHERE max_date > next_sol_min_date) AS ordering_violations,
+    (SELECT COUNT(*) FROM photos WHERE earth_date IS NULL) AS null_earth_dates";
 
-    // Aggregates ~1.5M rows via the rover/sol covering index; well under this,
-    // but the scrape runs unattended so give it headroom.
+    // One aggregate pass over ~1.5M rows (seq scan or index-only scan on the
+    // rover/sol covering index; ~100 ms class either way) - the timeout is
+    // generous headroom because the scrape runs unattended.
     private const int CommandTimeoutSeconds = 120;
 
     private readonly MarsVistaDbContext _context;
@@ -50,7 +62,7 @@ SELECT COUNT(*) FROM paired WHERE max_date > next_sol_min_date";
         _context = context;
     }
 
-    public async Task<int> CountViolationsAsync(CancellationToken cancellationToken = default)
+    public async Task<EarthDateInvariantResult> CheckAsync(CancellationToken cancellationToken = default)
     {
         var connection = _context.Database.GetDbConnection();
 
@@ -63,11 +75,14 @@ SELECT COUNT(*) FROM paired WHERE max_date > next_sol_min_date";
         try
         {
             await using var command = connection.CreateCommand();
-            command.CommandText = ViolationCountSql;
+            command.CommandText = InvariantCheckSql;
             command.CommandTimeout = CommandTimeoutSeconds;
 
-            var result = await command.ExecuteScalarAsync(cancellationToken);
-            return Convert.ToInt32(result);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            await reader.ReadAsync(cancellationToken);
+            return new EarthDateInvariantResult(
+                Convert.ToInt32(reader.GetValue(0)),
+                Convert.ToInt32(reader.GetValue(1)));
         }
         finally
         {

--- a/src/MarsVista.Core/Services/EarthDateMonotonicityCheck.cs
+++ b/src/MarsVista.Core/Services/EarthDateMonotonicityCheck.cs
@@ -1,0 +1,80 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using MarsVista.Core.Data;
+
+namespace MarsVista.Core.Services;
+
+/// <summary>
+/// Data-quality tripwire for the sol/earth_date ordering invariant: within one
+/// rover, a later sol must never carry an earlier earth_date. The API's
+/// sol-first sort optimization for earth_date sorts is order-preserving only
+/// while this holds (see PhotoQueryServiceV2.ApplySorting). Legacy rows carry
+/// NASA's sol-aligned attribution, but rows ingested by the current scrapers
+/// derive earth_date from date_taken_utc - so a NASA timestamp anomaly
+/// crossing UTC midnight would break the invariant silently. The daily scrape
+/// runs this check so a break is loud instead.
+/// </summary>
+public interface IEarthDateMonotonicityCheck
+{
+    /// <summary>
+    /// Counts pairs of consecutive sols (per rover) where the earlier sol's
+    /// latest earth_date exceeds the later sol's earliest. Zero means the
+    /// invariant holds.
+    /// </summary>
+    Task<int> CountViolationsAsync(CancellationToken cancellationToken = default);
+}
+
+public class EarthDateMonotonicityCheck : IEarthDateMonotonicityCheck
+{
+    private const string ViolationCountSql = @"
+WITH per_sol AS (
+    SELECT rover_id, sol, MIN(earth_date) AS min_date, MAX(earth_date) AS max_date
+    FROM photos
+    GROUP BY rover_id, sol
+),
+paired AS (
+    SELECT max_date,
+           LEAD(min_date) OVER (PARTITION BY rover_id ORDER BY sol) AS next_sol_min_date
+    FROM per_sol
+)
+SELECT COUNT(*) FROM paired WHERE max_date > next_sol_min_date";
+
+    // Aggregates ~1.5M rows via the rover/sol covering index; well under this,
+    // but the scrape runs unattended so give it headroom.
+    private const int CommandTimeoutSeconds = 120;
+
+    private readonly MarsVistaDbContext _context;
+
+    public EarthDateMonotonicityCheck(MarsVistaDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> CountViolationsAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = _context.Database.GetDbConnection();
+
+        var openedHere = connection.State != ConnectionState.Open;
+        if (openedHere)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = ViolationCountSql;
+            command.CommandTimeout = CommandTimeoutSeconds;
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(result);
+        }
+        finally
+        {
+            if (openedHere)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+}

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -80,6 +80,11 @@ try
     builder.Services.AddScoped<MarsVista.Core.Services.IUsageEventRetentionService,
         MarsVista.Core.Services.UsageEventRetentionService>();
 
+    // Data-quality tripwire for the API's sol-first earth_date sort; see the
+    // post-scrape maintenance block below.
+    builder.Services.AddScoped<MarsVista.Core.Services.IEarthDateMonotonicityCheck,
+        MarsVista.Core.Services.EarthDateMonotonicityCheck>();
+
     // Panorama pre-compute services (backfill mode + daily incremental refresh)
     builder.Services.AddScoped<MarsVista.Core.Services.PanoramaDetector>();
     builder.Services.AddScoped<MarsVista.Core.Services.IPanoramaTableBuilder,
@@ -233,6 +238,33 @@ try
     catch (Exception ex)
     {
         Log.Error(ex, "Usage-event retention failed (scrape result unaffected)");
+    }
+
+    // Data-quality tripwire: the API's sol-first earth_date sort optimization
+    // is order-preserving only while sol/earth_date stay monotone per rover;
+    // current scrapers derive earth_date from NASA timestamps, which have
+    // produced sol-misaligned values before. Loud here, on the run that
+    // ingests, instead of silently reordering API responses.
+    try
+    {
+        using var checkScope = host.Services.CreateScope();
+        var monotonicityCheck = checkScope.ServiceProvider
+            .GetRequiredService<MarsVista.Core.Services.IEarthDateMonotonicityCheck>();
+        var violations = await monotonicityCheck.CountViolationsAsync();
+        if (violations > 0)
+        {
+            Log.Error(
+                "sol/earth_date ordering violations detected: {Violations} sol boundaries out of order - the API's sol-first earth_date sort no longer preserves earth_date order",
+                violations);
+        }
+        else
+        {
+            Log.Information("sol/earth_date ordering invariant holds (0 violations)");
+        }
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "sol/earth_date monotonicity check failed (scrape result unaffected)");
     }
 
     Log.Information("Mars Vista Scraper finished");

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -250,16 +250,22 @@ try
         using var checkScope = host.Services.CreateScope();
         var monotonicityCheck = checkScope.ServiceProvider
             .GetRequiredService<MarsVista.Core.Services.IEarthDateMonotonicityCheck>();
-        var violations = await monotonicityCheck.CountViolationsAsync();
-        if (violations > 0)
+        var invariant = await monotonicityCheck.CheckAsync();
+        if (invariant.OrderingViolations > 0)
         {
             Log.Error(
                 "sol/earth_date ordering violations detected: {Violations} sol boundaries out of order - the API's sol-first earth_date sort no longer preserves earth_date order",
-                violations);
+                invariant.OrderingViolations);
         }
-        else
+        if (invariant.NullEarthDates > 0)
         {
-            Log.Information("sol/earth_date ordering invariant holds (0 violations)");
+            Log.Error(
+                "photos with NULL earth_date detected: {Count} - invisible to the ordering check and ordered differently by the sol-prefixed sort than by a plain earth_date sort",
+                invariant.NullEarthDates);
+        }
+        if (invariant.OrderingViolations == 0 && invariant.NullEarthDates == 0)
+        {
+            Log.Information("sol/earth_date ordering invariant holds (0 violations, 0 NULLs)");
         }
     }
     catch (Exception ex)

--- a/tests/MarsVista.Api.Tests/Integration/EarthDateMonotonicityCheckTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/EarthDateMonotonicityCheckTests.cs
@@ -8,8 +8,10 @@ namespace MarsVista.Api.Tests.Integration;
 /// <summary>
 /// The daily scrape runs this check as a tripwire for the sol/earth_date
 /// ordering invariant the API's sol-first earth_date sort depends on. These
-/// tests prove the check actually fires on out-of-order data - the failure
-/// mode it guards against is precisely a check that stays silent.
+/// tests prove the check actually fires on out-of-order data and on NULL
+/// earth_dates - the failure mode it guards against is precisely a check that
+/// stays silent - and that it does NOT fire on the shapes production data
+/// takes every day (shared boundary dates, per-rover partitions).
 /// </summary>
 public class EarthDateMonotonicityCheckTests : IntegrationTestBase
 {
@@ -18,16 +20,20 @@ public class EarthDateMonotonicityCheckTests : IntegrationTestBase
         services.AddScoped<IEarthDateMonotonicityCheck, EarthDateMonotonicityCheck>();
     }
 
-    private Photo MakePhoto(string nasaId, int sol, DateTime earthDate) => new()
+    private Photo MakePhoto(string nasaId, int sol, DateTime? earthDate, int roverId = 1) => new()
     {
         NasaId = nasaId, ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
-        Sol = sol, EarthDate = earthDate, DateTakenUtc = earthDate,
-        SampleType = "Full", RoverId = 1, CameraId = 1,
+        Sol = sol, EarthDate = earthDate,
+        DateTakenUtc = earthDate ?? new DateTime(2013, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        SampleType = "Full", RoverId = roverId, CameraId = 1,
         CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
     };
 
+    private IEarthDateMonotonicityCheck Check =>
+        ServiceProvider.GetRequiredService<IEarthDateMonotonicityCheck>();
+
     [Fact]
-    public async Task ConcordantData_ReportsZeroViolations()
+    public async Task ConcordantData_ReportsClean()
     {
         DbContext.Photos.AddRange(
             MakePhoto("MONO-A", 10, new DateTime(2013, 1, 10, 0, 0, 0, DateTimeKind.Utc)),
@@ -35,9 +41,9 @@ public class EarthDateMonotonicityCheckTests : IntegrationTestBase
             MakePhoto("MONO-C", 12, new DateTime(2013, 1, 12, 0, 0, 0, DateTimeKind.Utc)));
         await DbContext.SaveChangesAsync();
 
-        var check = ServiceProvider.GetRequiredService<IEarthDateMonotonicityCheck>();
+        var result = await Check.CheckAsync();
 
-        (await check.CountViolationsAsync()).Should().Be(0);
+        result.Should().Be(new EarthDateInvariantResult(0, 0));
     }
 
     [Fact]
@@ -50,8 +56,60 @@ public class EarthDateMonotonicityCheckTests : IntegrationTestBase
             MakePhoto("MONO-BAD", 21, new DateTime(2013, 2, 15, 0, 0, 0, DateTimeKind.Utc)));
         await DbContext.SaveChangesAsync();
 
-        var check = ServiceProvider.GetRequiredService<IEarthDateMonotonicityCheck>();
+        var result = await Check.CheckAsync();
 
-        (await check.CountViolationsAsync()).Should().BeGreaterThan(0);
+        // Exactly one boundary violates, however many photos each sol holds.
+        result.OrderingViolations.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AdjacentSolsSharingABoundaryDate_AreNotViolations()
+    {
+        // The everyday production shape: a sol spans two Earth dates, so
+        // consecutive sols routinely share the boundary date. The comparison
+        // must stay strict - a > to >= regression would fire on thousands of
+        // legitimate boundaries nightly.
+        var shared = new DateTime(2013, 3, 5, 0, 0, 0, DateTimeKind.Utc);
+        DbContext.Photos.AddRange(
+            MakePhoto("MONO-EQ-A", 30, shared),
+            MakePhoto("MONO-EQ-B", 31, shared),
+            MakePhoto("MONO-EQ-C", 31, new DateTime(2013, 3, 6, 0, 0, 0, DateTimeKind.Utc)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Check.CheckAsync();
+
+        result.OrderingViolations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RoversAreComparedIndependently()
+    {
+        // Rover missions overlap in time: one rover's late sols carry later
+        // dates than another rover's early sols. The window must partition by
+        // rover so mission boundaries never pair.
+        DbContext.Photos.AddRange(
+            MakePhoto("MONO-R1", 100, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc), roverId: 1),
+            MakePhoto("MONO-R2", 1, new DateTime(2004, 1, 5, 0, 0, 0, DateTimeKind.Utc), roverId: 2));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Check.CheckAsync();
+
+        result.OrderingViolations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NullEarthDates_AreCountedSeparately()
+    {
+        // NULLs silently drop out of the ordering comparison (an all-NULL sol
+        // even masks a real violation across it), so they are alarmed on
+        // directly rather than left invisible.
+        DbContext.Photos.AddRange(
+            MakePhoto("MONO-NULL-A", 40, new DateTime(2013, 4, 10, 0, 0, 0, DateTimeKind.Utc)),
+            MakePhoto("MONO-NULL-B", 41, earthDate: null));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Check.CheckAsync();
+
+        result.NullEarthDates.Should().Be(1);
     }
 }

--- a/tests/MarsVista.Api.Tests/Integration/EarthDateMonotonicityCheckTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/EarthDateMonotonicityCheckTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MarsVista.Core.Entities;
+using MarsVista.Core.Services;
+
+namespace MarsVista.Api.Tests.Integration;
+
+/// <summary>
+/// The daily scrape runs this check as a tripwire for the sol/earth_date
+/// ordering invariant the API's sol-first earth_date sort depends on. These
+/// tests prove the check actually fires on out-of-order data - the failure
+/// mode it guards against is precisely a check that stays silent.
+/// </summary>
+public class EarthDateMonotonicityCheckTests : IntegrationTestBase
+{
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IEarthDateMonotonicityCheck, EarthDateMonotonicityCheck>();
+    }
+
+    private Photo MakePhoto(string nasaId, int sol, DateTime earthDate) => new()
+    {
+        NasaId = nasaId, ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+        Sol = sol, EarthDate = earthDate, DateTakenUtc = earthDate,
+        SampleType = "Full", RoverId = 1, CameraId = 1,
+        CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task ConcordantData_ReportsZeroViolations()
+    {
+        DbContext.Photos.AddRange(
+            MakePhoto("MONO-A", 10, new DateTime(2013, 1, 10, 0, 0, 0, DateTimeKind.Utc)),
+            MakePhoto("MONO-B", 11, new DateTime(2013, 1, 11, 0, 0, 0, DateTimeKind.Utc)),
+            MakePhoto("MONO-C", 12, new DateTime(2013, 1, 12, 0, 0, 0, DateTimeKind.Utc)));
+        await DbContext.SaveChangesAsync();
+
+        var check = ServiceProvider.GetRequiredService<IEarthDateMonotonicityCheck>();
+
+        (await check.CountViolationsAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LaterSolWithEarlierEarthDate_IsDetected()
+    {
+        // Sol 21's earth_date precedes sol 20's - the anomaly shape NASA has
+        // produced before (mis-attributed timestamps around sol boundaries).
+        DbContext.Photos.AddRange(
+            MakePhoto("MONO-OK", 20, new DateTime(2013, 2, 20, 0, 0, 0, DateTimeKind.Utc)),
+            MakePhoto("MONO-BAD", 21, new DateTime(2013, 2, 15, 0, 0, 0, DateTimeKind.Utc)));
+        await DbContext.SaveChangesAsync();
+
+        var check = ServiceProvider.GetRequiredService<IEarthDateMonotonicityCheck>();
+
+        (await check.CountViolationsAsync()).Should().BeGreaterThan(0);
+    }
+}

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -211,12 +211,94 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
 
         foreach (var sql in dataSql)
         {
-            // EF emits no keyword for ascending, so sol must be followed
-            // directly by the comma.
+            // EF emits no keyword for ascending, so both keys must be followed
+            // directly by a comma / end - not DESC.
             sql.Should().MatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?\s*,\s*\S*\.?""?earth_date""?",
-                "ascending earth_date must get an ascending sol prefix");
+                @"ORDER BY\s+\S*\.?""?sol""?\s*,\s*\S*\.?""?earth_date""?(?!\s+DESC)",
+                "ascending earth_date must get an ascending sol prefix, both ascending");
         }
+    }
+
+    [Fact]
+    public async Task SingleRoverExplicitDateTakenAscending_GetsAscendingSolPrefix()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "date_taken_utc", Direction = SortDirection.Ascending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s*,\s*\S*\.?""?date_taken_utc""?(?!\s+DESC)",
+                "ascending date_taken_utc must get an ascending sol prefix, both ascending");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverDateTakenSortWithNavigationTail_KeepsJoinedTail()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
+            new() { Field = "camera", Direction = SortDirection.Ascending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            // The camera tail sorts on the joined cameras.name; the sol seed
+            // must not disturb how the navigation tail is composed.
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?date_taken_utc""?\s+DESC\s*,\s*\S*\.?""?name""?",
+                "a navigation-property tail must follow the sol prefix intact");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverExplicitDateTakenSort_SolWinsOverDiscordantDate()
+    {
+        // Pins the accepted trade-off consciously for the EXPLICIT sort, not
+        // just the default: where sol and timestamp disagree (the 17
+        // early-Perseverance boundary anomalies in production), sol-attributed
+        // order wins even though the caller literally asked for timestamp
+        // order. Under a pure -date_taken_utc sort these would come back
+        // reversed.
+        var now = DateTime.UtcNow;
+        DbContext.Photos.AddRange(
+            new Photo
+            {
+                NasaId = "XDIS-SOL-WINS", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 3100, EarthDate = new DateTime(2013, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2013, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            },
+            new Photo
+            {
+                NasaId = "XDIS-DATE-LOSES", ImgSrcFull = "x", ImgSrcLarge = "x", ImgSrcMedium = "x", ImgSrcSmall = "x",
+                Sol = 3000, EarthDate = new DateTime(2015, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+                DateTakenUtc = new DateTime(2015, 7, 1, 10, 0, 0, DateTimeKind.Utc),
+                SampleType = "Full", RoverId = 1, CameraId = 1,
+                CreatedAt = now, UpdatedAt = now,
+            });
+        await DbContext.SaveChangesAsync();
+
+        var parameters = new PhotoQueryParameters
+        {
+            Rovers = "curiosity",
+            RoverList = new List<string> { "curiosity" },
+            SolMin = 3000, SolMax = 3200,
+            SortFields = new List<SortField>
+            {
+                new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
+            },
+            Page = 1, PerPage = 10,
+        };
+
+        var response = await _photoQueryService.QueryPhotosAsync(parameters, default);
+
+        response.Data.Select(p => p.Attributes!.NasaId).Should().Equal(
+            "XDIS-SOL-WINS", "XDIS-DATE-LOSES");
     }
 
     [Fact]

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -157,7 +157,7 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         foreach (var sql in dataSql)
         {
             sql.Should().NotMatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?",
+                @"ORDER BY[\s\S]*\bsol\b",
                 "multi-rover queries must not sort by sol - sols are not comparable across rovers");
         }
     }
@@ -332,7 +332,7 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
             // Adjacent sols share earth_dates, so a sol prefix would override
             // the caller's camera tiebreak for same-date photos.
             sql.Should().NotMatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?",
+                @"ORDER BY[\s\S]*\bsol\b",
                 "earth_date with an explicit tiebreak must be honoured exactly as given");
         }
     }
@@ -348,7 +348,7 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         foreach (var sql in dataSql)
         {
             sql.Should().NotMatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?",
+                @"ORDER BY[\s\S]*\bsol\b",
                 "sols are not comparable across rovers");
         }
     }
@@ -364,7 +364,7 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         foreach (var sql in dataSql)
         {
             sql.Should().NotMatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?",
+                @"ORDER BY[\s\S]*\bsol\b",
                 "only date-family sorts benefit from a sol prefix");
         }
     }

--- a/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
+++ b/tests/MarsVista.Api.Tests/Integration/V2/PhotoQuerySqlGenerationTests.cs
@@ -162,40 +162,156 @@ public class PhotoQuerySqlGenerationTests : IntegrationTestBase
         }
     }
 
+    // Explicit date-family sorts on single-rover queries get the same sol
+    // prefix as the default sort, in the requested direction - the prefix only
+    // refines ties the caller left unspecified (earth_date is verified
+    // perfectly sol-monotone in production; date_taken_utc modulo the known
+    // early-Perseverance anomalies). Sorts where the prefix could reorder an
+    // explicit tiebreak (earth_date with a tail) are left exactly as given.
+
     [Fact]
-    public async Task SingleRoverExplicitDateSort_KeepsDateOnlyOrder()
+    public async Task SingleRoverExplicitDateTakenSort_GetsSolPrefix()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?date_taken_utc""?\s+DESC",
+                "explicit -date_taken_utc on a single rover must be served sol-first");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverExplicitEarthDateSort_GetsSolPrefix()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "earth_date", Direction = SortDirection.Descending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?earth_date""?\s+DESC",
+                "explicit -earth_date on a single rover must be served sol-first");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverExplicitEarthDateAscending_GetsAscendingSolPrefix()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "earth_date", Direction = SortDirection.Ascending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            // EF emits no keyword for ascending, so sol must be followed
+            // directly by the comma.
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s*,\s*\S*\.?""?earth_date""?",
+                "ascending earth_date must get an ascending sol prefix");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverDateTakenSortWithTail_KeepsTailAfterSolPrefix()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
+            new() { Field = "id", Direction = SortDirection.Descending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().MatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?\s+DESC\s*,\s*\S*\.?""?date_taken_utc""?\s+DESC\s*,\s*\S*\.?""?id""?\s+DESC",
+                "the caller's tiebreak tail must follow the sol prefix intact");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverEarthDateSortWithTail_StaysAsGiven()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "earth_date", Direction = SortDirection.Descending },
+            new() { Field = "camera", Direction = SortDirection.Ascending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            // Adjacent sols share earth_dates, so a sol prefix would override
+            // the caller's camera tiebreak for same-date photos.
+            sql.Should().NotMatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?",
+                "earth_date with an explicit tiebreak must be honoured exactly as given");
+        }
+    }
+
+    [Fact]
+    public async Task MultiRoverExplicitEarthDateSort_StaysAsGiven()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity,perseverance", new List<SortField>
+        {
+            new() { Field = "earth_date", Direction = SortDirection.Descending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().NotMatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?",
+                "sols are not comparable across rovers");
+        }
+    }
+
+    [Fact]
+    public async Task SingleRoverNonDateSort_StaysAsGiven()
+    {
+        var dataSql = await CaptureOrderedSql("curiosity", new List<SortField>
+        {
+            new() { Field = "id", Direction = SortDirection.Descending },
+        });
+
+        foreach (var sql in dataSql)
+        {
+            sql.Should().NotMatchRegex(
+                @"ORDER BY\s+\S*\.?""?sol""?",
+                "only date-family sorts benefit from a sol prefix");
+        }
+    }
+
+    /// <summary>
+    /// Runs a query with the given rovers and explicit sort, returning the
+    /// captured ORDER BY SQL. The validator normally parses Sort into
+    /// SortFields before the service runs; tests set SortFields directly.
+    /// </summary>
+    private async Task<List<string>> CaptureOrderedSql(string rovers, List<SortField> sortFields)
     {
         SqlCapture.Clear();
 
         var parameters = new PhotoQueryParameters
         {
-            Rovers = "curiosity",
-            RoverList = new List<string> { "curiosity" },
-            // The validator normally parses Sort into SortFields before the
-            // service runs; the service only reads SortFields.
-            Sort = "-date_taken_utc",
-            SortFields = new List<SortField>
-            {
-                new() { Field = "date_taken_utc", Direction = SortDirection.Descending },
-            },
+            Rovers = rovers,
+            RoverList = rovers.Split(',').ToList(),
+            SortFields = sortFields,
             Page = 1, PerPage = 10,
         };
 
         await _photoQueryService.QueryPhotosAsync(parameters, default);
 
-        // An explicit sort is the caller's contract; only the default sort is
-        // rewritten to the sol-first equivalent.
         var dataSql = SqlCapture.ExecutedSql
             .Where(s => s.Contains("ORDER BY", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         dataSql.Should().NotBeEmpty();
-        foreach (var sql in dataSql)
-        {
-            sql.Should().NotMatchRegex(
-                @"ORDER BY\s+\S*\.?""?sol""?",
-                "explicit sort=-date_taken_utc must be honoured as given");
-        }
+        return dataSql;
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Yesterday's health check flagged the last slow query shape: an explicit `sort=-earth_date` (or `-date_taken_utc`) over a wide sol range still hit the planner pathology that #29 fixed for the default sort. `EXPLAIN ANALYZE` on production: backward scan of `ix_photos_rover_id_earth_date` discarding **638,897 rows** before finding 10 matches — **2,010 ms** server-side. It also meant the workaround our own docs recommend (`sort=-date_taken_utc,-id`) stayed on the slow path.

## Fix

For single-rover queries, prefix `sol` (in the requested direction) to explicit date-family sorts — but only where the prefix provably cannot reorder what the caller asked for, only refine ties they left unspecified:

| Requested sort | Rewritten? | Why |
|---|---|---|
| `-date_taken_utc` / `date_taken_utc` (alone or with a tail, e.g. `-date_taken_utc,-id`) | ✅ sol-prefixed | Within one rover, sol order is timestamp order. Identical timestamps spanning two sols exist for only **27 (rover, timestamp) groups in 1.5M photos** (measured), so an explicit tail is preserved intact in practice. |
| `-earth_date` / `earth_date` alone | ✅ sol-prefixed | `earth_date` derives from NASA's per-sol attribution and is **exactly sol-monotone** in production data — zero violations on any rover (measured, unlike `date_taken_utc`'s 17 anomalies). The prefixed order is still a valid `earth_date` order. |
| `earth_date` with a tail (e.g. `-earth_date,camera`) | ❌ as given | A sol spans two Earth dates, so adjacent sols share `earth_date`s — the prefix would override the caller's tiebreak for same-date photos. |
| Multi-rover, or non-date sorts | ❌ as given | Sols aren't comparable across rovers. |

Measured on production for the `-earth_date` shape (curiosity, MAST, sols 1–1000, top 10):

| | plan | rows read | time |
|---|---|---|---|
| before | backward scan of `ix_photos_rover_id_earth_date` | 639K discarded | 2,010 ms |
| after | index-satisfied ORDER BY on `ix_photos_rover_id_sol_covering` | 10 | **0.13 ms** |

This deliberately supersedes #29's decision to leave explicit sorts untouched — that scoping was a conservative first step, and the health check showed the shape is worth fixing.

## Testing

- The previous "explicit sort stays as given" pinning test is replaced by seven SQL-shape tests covering the rewrite (`-date_taken_utc`, `-earth_date`, ascending `earth_date`, `-date_taken_utc,-id` with tail intact) and the exclusions (`-earth_date,camera`, multi-rover, non-date sorts).
- The four rewrite tests fail without the change.
- Full suite: 503 tests pass.

## Review notes (independent adversarial review, isolated worktree — second and third commits)

The reviewer confirmed the mechanics (build, 340 tests, count-cache untouched, blast radius = v2 list only, degenerate sorts like `-date_taken_utc,sol` harmless) but found the **justification overclaimed**, and two follow-ups were applied:

**Honest framing (second commit).** The helper claimed the prefix "provably cannot reorder, only refine ties" — false for `date_taken_utc`: at the 17 anomalous Perseverance sol boundaries the prefix *inverts* the literal requested order, and strict raw-timestamp order across those boundaries is no longer obtainable for a single-rover query. That trade-off is kept deliberately (the timestamps there are unreliable; default and explicit timestamp sorts should agree) but is now stated as a trade-off — helper renamed to `ShouldPrefixSolToExplicitSort`, docs rewritten, and the accepted inversion pinned consciously by an explicit-sort discordant-pair test. The claimed `earth_date` provenance ("NASA's per-sol attribution") was also wrong for current ingests — the scrapers derive it from `date_taken_utc`; legacy rows carry NASA attribution, which is why production data is violation-free today. Also: empty-list guard, both-direction pins on ascending regexes, ascending `date_taken_utc` shape, and a navigation-tail (`camera`) test.

**Invariant tripwire (third commit).** The lone-`earth_date` case is order-preserving only while sol/earth_date stay monotone — an empirical property a future NASA timestamp anomaly could break silently. The daily scrape now runs `EarthDateMonotonicityCheck` (new Core service + integration tests proving it fires on out-of-order data) and logs at **error level** on any violation, best-effort like the retention step.

Note for merge: this adds a file to `MarsVista.Core`, so the ops repo's submodule needs its usual bump afterwards.

Full suite: 508 tests pass.

## Second review round (two independent reviewers, isolated worktrees — commits 4 and 5)

A fresh-eyes reviewer took the full cumulative diff with no knowledge of the first review, and a second reviewer deep-dived the tripwire commit alone (proving the SQL against a 9-scenario edge-case harness and a 1.5M-row probe with the real index). **Both independently found the same blind spot**, which strengthens confidence in the rest:

- **NULL `earth_date`s blinded the tripwire (both reviewers, confirmed empirically):** SQL NULL comparisons drop out of the boundary check, and an all-NULL sol masks a real violation across it by breaking the consecutive-pair chain — while NULLs also independently break the sort equivalence (NULLS-first under plain `earth_date DESC` vs sol-position under the prefix). The check now counts NULL `earth_date`s in the same statement and the scraper alarms on either count (production has zero today, so no noise). The helper doc names both preconditions.
- **Tripwire tests hardened (deep-dive):** exact violation-count pin, the equal-boundary-date case (the everyday production shape — a strict-to-non-strict comparison regression would fire on thousands of legitimate boundaries nightly), the cross-rover partition case, and an honest timing comment (the planner may prefer a parallel seq scan over the index-only scan; both ~100ms class).
- **The alarm path was a smoke alarm with no speaker (both reviewers):** the scraper had no Sentry — every scraper `Log.Error` (scrape failures, retention failures, these alarms) went only to unwatched Railway console logs. Fixed in **#33** (Sentry.Serilog sink at error level; pre-existing gap, so a separate PR).
- Minor doc/test tightening: `IsSingleRoverQuery`'s doc now names both consumers; the as-given sort tests reject `sol` anywhere in the ORDER BY clause, not just as the first key.

**Proven correct by the deep-dive harness:** single-sol rovers, sol gaps (LEAD pairs across gaps and catches gap-spanning violations), equal boundaries (not violations), cross-rover partition boundaries (never pair), one count per violating boundary regardless of photos per sol — and consecutive-pair checking is transitively complete on NULL-free data. The fresh-eyes reviewer additionally confirmed the rewrite logic is correct for every input reachable through the validator, and that the trade-off documentation now carries accurately through code comments, commit messages, and DECISION-023.

Full suite: 511 tests pass.
