### PR TITLE
Send scraper error logs to Sentry

### DIFF
--- a/src/MarsVista.Scraper/MarsVista.Scraper.csproj
+++ b/src/MarsVista.Scraper/MarsVista.Scraper.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+    <PackageReference Include="Sentry.Serilog" Version="5.16.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/MarsVista.Scraper/Program.cs
+++ b/src/MarsVista.Scraper/Program.cs
@@ -13,14 +13,31 @@ using Serilog;
 using Serilog.Formatting.Compact;
 
 // Configure Serilog
-Log.Logger = new LoggerConfiguration()
+var loggerConfiguration = new LoggerConfiguration()
     .MinimumLevel.Information()
     // Silence EF Core's per-command logging (matches the API config) so scrape
     // and backfill progress is not buried under a flood of SQL command logs.
     .MinimumLevel.Override("Microsoft.EntityFrameworkCore", Serilog.Events.LogEventLevel.Warning)
     .Enrich.FromLogContext()
-    .WriteTo.Console(new CompactJsonFormatter())
-    .CreateLogger();
+    .WriteTo.Console(new CompactJsonFormatter());
+
+// Error-level events go to Sentry so scrape failures, retention failures, and
+// data-quality alarms are actually seen - Railway console logs are not
+// actively watched. Without SENTRY_DSN (e.g. local runs) logging is
+// console-only, matching the API's opt-in behavior.
+var sentryDsn = Environment.GetEnvironmentVariable("SENTRY_DSN");
+if (!string.IsNullOrEmpty(sentryDsn))
+{
+    loggerConfiguration = loggerConfiguration.WriteTo.Sentry(options =>
+    {
+        options.Dsn = sentryDsn;
+        options.MinimumEventLevel = Serilog.Events.LogEventLevel.Error;
+        options.MinimumBreadcrumbLevel = Serilog.Events.LogEventLevel.Information;
+        options.Environment = Environment.GetEnvironmentVariable("RAILWAY_ENVIRONMENT_NAME") ?? "production";
+    });
+}
+
+Log.Logger = loggerConfiguration.CreateLogger();
 
 try
 {


### PR DESCRIPTION
Independent review of the data-quality tripwire in #32 confirmed a pre-existing gap: the scraper logs only to console JSON, which Railway captures but nobody actively watches. Every `Log.Error` path — scrape failures, usage-event retention failures, panorama refresh failures, and now the sol/earth_date invariant alarms — rang in an empty room, while the API's errors go to Sentry.

This adds the `Sentry.Serilog` sink (version matched to the API's Sentry package line) at error level, with information-level breadcrumbs for context. Keyed off a `SENTRY_DSN` environment variable and silent without it, so local runs stay console-only — the same opt-in behavior as the API.

**Deploy note:** after merging, set `SENTRY_DSN` on the Railway scraper service (the API's DSN can be reused — events are distinguished by logger context; or create a separate Sentry project if you prefer separate alert routing).

Scraper builds clean; all 163 scraper tests pass.