### PR TITLE
Give runtime queries their own command timeout

### DIFF
--- a/src/MarsVista.Api/Program.cs
+++ b/src/MarsVista.Api/Program.cs
@@ -104,9 +104,14 @@ builder.Services.AddDbContext<MarsVistaDbContext>((serviceProvider, options) =>
             // Split queries for better performance with Include()
             npgsqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
 
-            // Command timeout: 120s for migrations (computed columns on 630K+ photos), 30s for queries
-            // Migrations run at startup, so longer timeout is acceptable
-            npgsqlOptions.CommandTimeout(120);
+            // Seconds. Bounds a single request's wait on the database: the
+            // slowest legitimate query observed in production is ~7 s, so this
+            // is headroom, not a target. Startup migrations need far longer and
+            // raise it on their own connection (see MigrateAsync below) rather
+            // than widening it for every request - a request that waits minutes
+            // holds a pool slot, and enough of those exhaust the pool and take
+            // the API down with the database.
+            npgsqlOptions.CommandTimeout(30);
 
             // Batch multiple operations
             npgsqlOptions.MaxBatchSize(100);
@@ -392,6 +397,10 @@ var app = builder.Build();
 using (var scope = app.Services.CreateScope())
 {
     var dbContext = scope.ServiceProvider.GetRequiredService<MarsVistaDbContext>();
+    // Migrations are the one operation that legitimately runs for minutes -
+    // adding a computed column rewrites every row of a 1.5M-row table. Raised
+    // here so the request path can keep its short timeout.
+    dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
     await dbContext.Database.MigrateAsync();
 }
 


### PR DESCRIPTION
## Goal

`CommandTimeout` was 120 s for everything, chosen for startup migrations. The
comment above it already claimed *"30s for queries"* — nothing implemented
that. Combined with `EnableRetryOnFailure(maxRetryCount: 3)`, a single request
could wait on the database for up to eight minutes.

## Why it matters

This is what turned a slow database into an unavailable API on 2026-08-10.
Between 03:12 and 04:20 UTC the Photo Postgres was I/O-starved; photo lookups
sat at ~300 s each while holding a connection pool slot, and from 03:30 to
04:19 **no request completed at all**.

The outage left no request log: `UsageTrackingMiddleware` writes `usage_events`
to the same database that was unreachable, and auth failed for the same reason
— the Sentry stacks bottom out in `ApiKeyMiddleware.InvokeAsync`. A database
outage is invisible in our own request telemetry.

## Change

Runtime queries time out at 30 s — roughly four times the slowest legitimate
query observed in production (~7 s). Migrations set their own 10-minute timeout
on the startup connection, where a multi-minute operation is expected: adding a
computed column rewrites every row of a 1.5M-row table.

## Left out

Retry compounding remains: four attempts at 30 s is still 120 s of a held pool
slot. That is a 4× improvement, not a fix — tightening the retry policy changes
resilience behaviour and needs its own change with its own reasoning.

No test. `Program.cs` composition has no test seam here; `IntegrationTestBase`
builds its own `DbContext` and would not exercise this configuration.

## Context

Related: `mars-vista-web` removes the dashboard polling that kept the database
disk-bound; `mars-vista-ops` makes the admin queries cheap. Incident record in
`mars-vista-docs`.